### PR TITLE
main: [minor] fix border around linux kernel message

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func warning() {
 	fmt.Fprintln(os.Stderr, "│       kernel has first class support for AmneziaWG. For      │")
 	fmt.Fprintln(os.Stderr, "│       information on installing the kernel module,           │")
 	fmt.Fprintln(os.Stderr, "│       please visit:                                          │")
-	fmt.Fprintln(os.Stderr, "| https://github.com/amnezia-vpn/amneziawg-linux-kernel-module │")
+	fmt.Fprintln(os.Stderr, "│ https://github.com/amnezia-vpn/amneziawg-linux-kernel-module │")
 	fmt.Fprintln(os.Stderr, "│                                                              │")
 	fmt.Fprintln(os.Stderr, "└──────────────────────────────────────────────────────────────┘")
 }


### PR DESCRIPTION
Modern terminals cheat while render "ASCII-boxes": instead of relying on fonts they draw lines directly. That grants beautiful lines without spacing or tears, but also highlights when other characters are used.