### PR TITLE
fix: apply S4 transport padding to keepalive packets

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -572,18 +572,15 @@ func (peer *Peer) RoutineSequentialSender(maxBatchSize int) {
 		dataSent := false
 		elemsContainer.Lock()
 		for _, elem := range elemsContainer.elems {
-			if len(elem.packet) != MessageKeepaliveSize {
-				dataSent = true
-
-				if padding := device.paddings.transport; padding > 0 {
-					// elem.packet is stored at the start of elem.buffer
-					// with zero padding
-					for i := len(elem.packet) - 1; i >= 0; i-- {
-						elem.buffer[i+padding] = elem.buffer[i]
-					}
-					rand.Read(elem.buffer[:padding])
-					elem.packet = elem.buffer[:padding+len(elem.packet)]
+			dataSent = dataSent || len(elem.packet) != MessageKeepaliveSize
+			if padding := device.paddings.transport; padding > 0 {
+				// elem.packet is stored at the start of elem.buffer
+				// with zero padding
+				for i := len(elem.packet) - 1; i >= 0; i-- {
+					elem.buffer[i+padding] = elem.buffer[i]
 				}
+				rand.Read(elem.buffer[:padding])
+				elem.packet = elem.buffer[:padding+len(elem.packet)]
 			}
 			bufs = append(bufs, elem.packet)
 		}


### PR DESCRIPTION
## Bug

When S4 (transport padding) is non-zero, keepalive packets are sent **without** S4 padding, but the receiving side expects **all** transport packets to include it. This causes keepalives to be silently dropped, preventing the responder from ever calling `timersHandshakeComplete()`.

## Root cause

In `device/send.go`, `RoutineSequentialSender` only adds S4 padding inside the `if len(elem.packet) != MessageKeepaliveSize` branch:

```go
// device/send.go:574-587
for _, elem := range elemsContainer.elems {
    if len(elem.packet) != MessageKeepaliveSize {
        dataSent = true

        if padding := device.paddings.transport; padding > 0 {
            // ... prepend S4 random bytes ...
        }
    }
    bufs = append(bufs, elem.packet)
}
```

Keepalive packets (`len == MessageKeepaliveSize`) skip the padding entirely.

On the receive side, `DeterminePacketTypeAndPadding` unconditionally expects S4 padding on all transport packets:

```go
// device/receive.go:602-611
if size >= padding+MessageTransportHeaderSize {
    data := packet[padding:]
    if header.Validate(binary.LittleEndian.Uint32(data)) {
        return MessageTransportType, padding
    }
}
```

A keepalive without padding is smaller than `padding + MessageTransportHeaderSize`, so it fails the size check and is classified as `MessageUnknownType` → dropped.

## Impact

After a handshake, the **initiator** immediately sends a keepalive to the responder. Since the keepalive is dropped, the responder never receives key confirmation and `lastHandshakeNano` stays at 0. The handshake only fully completes on the responder side when actual data traffic flows through the tunnel.

**When S4 = 0 there is no issue** — padding is 0, keepalive passes the size check normally.

## Fix

Move the padding logic out of the `dataSent` guard so it applies to all transport packets including keepalives.