### PR TITLE
fix: apply S4 transport padding to keepalive packets

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -574,16 +574,15 @@ func (peer *Peer) RoutineSequentialSender(maxBatchSize int) {
 		for _, elem := range elemsContainer.elems {
 			if len(elem.packet) != MessageKeepaliveSize {
 				dataSent = true
-
-				if padding := device.paddings.transport; padding > 0 {
-					// elem.packet is stored at the start of elem.buffer
-					// with zero padding
-					for i := len(elem.packet) - 1; i >= 0; i-- {
-						elem.buffer[i+padding] = elem.buffer[i]
-					}
-					rand.Read(elem.buffer[:padding])
-					elem.packet = elem.buffer[:padding+len(elem.packet)]
+			}
+			if padding := device.paddings.transport; padding > 0 {
+				// elem.packet is stored at the start of elem.buffer
+				// with zero padding
+				for i := len(elem.packet) - 1; i >= 0; i-- {
+					elem.buffer[i+padding] = elem.buffer[i]
 				}
+				rand.Read(elem.buffer[:padding])
+				elem.packet = elem.buffer[:padding+len(elem.packet)]
 			}
 			bufs = append(bufs, elem.packet)
 		}


### PR DESCRIPTION
## Bug

When S4 (transport padding) is non-zero, keepalive packets are sent **without** S4 padding, but the receiving side expects **all** transport packets to include it. This causes keepalives to be silently dropped, preventing the responder from ever calling `timersHandshakeComplete()`.

## Root cause

In `device/send.go:574-587`, `RoutineSequentialSender` only adds S4 padding inside the `if len(elem.packet) != MessageKeepaliveSize` branch:

```go
for _, elem := range elemsContainer.elems {
    if len(elem.packet) != MessageKeepaliveSize {
        dataSent = true

        if padding := device.paddings.transport; padding > 0 {
            // ... prepend S4 random bytes ...
        }
    }
    bufs = append(bufs, elem.packet)
}
```

Keepalive packets (`len == MessageKeepaliveSize`) skip the padding entirely.

On the receive side (`device/receive.go:602-611`), `DeterminePacketTypeAndPadding` unconditionally expects S4 padding on all transport packets:

```go
if size >= padding+MessageTransportHeaderSize {
    data := packet[padding:]
    if header.Validate(binary.LittleEndian.Uint32(data)) {
        return MessageTransportType, padding
    }
}
```

An unpadded keepalive (32 bytes) passes the size check when S4 is small, but `packet[S4:]` points into the middle of the real header — H4 validation fails and the packet is classified as `MessageUnknownType` → dropped.

## What happens

1. **Initiator** completes handshake → stores keypair as `current` → calls `timersHandshakeComplete()` → sends keepalive
2. **Responder** sends handshake response (with S2 padding, separate code path) → stores keypair as `next` (not `current`) → waits for first transport packet to promote keypair and call `timersHandshakeComplete()`
3. Keepalive arrives **without S4 padding** → `DeterminePacketTypeAndPadding` fails → packet dropped
4. Responder's `lastHandshakeNano` stays at **0** — keypair is never promoted from `next` to `current`
5. Real data packets have S4 padding applied → arrive correctly → handshake completes on responder

**When S4 = 0 there is no issue** — no padding expected, keepalive passes normally.

## Fix

`device/send.go:574-587` — `dataSent` and padding are independent concerns: `dataSent` controls `timersDataSent()`, padding is a property of all transport packets. Close the `dataSent` guard before the padding block so it applies to keepalives too.