### PR TITLE
fix: docker build warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4 as awg
+FROM golang:1.24.4 AS awg
 COPY . /awg
 WORKDIR /awg
 RUN go mod download && \


### PR DESCRIPTION
> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)