### PR TITLE
device: apply S4 transport padding to keepalive packets

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -249,6 +249,144 @@ func TestAWGDevicePing(t *testing.T) {
 	})
 }
 
+// spyBind wraps a conn.Bind and captures copies of all sent packets.
+// Used by TestKeepaliveIncludesS4Padding to verify wire format.
+type spyBind struct {
+	conn.Bind
+	packets chan []byte
+}
+
+func newSpyBind(b conn.Bind) *spyBind {
+	return &spyBind{
+		Bind:    b,
+		packets: make(chan []byte, 4096),
+	}
+}
+
+func (s *spyBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+	for _, b := range bufs {
+		pkt := make([]byte, len(b))
+		copy(pkt, b)
+		select {
+		case s.packets <- pkt:
+		default:
+		}
+	}
+	return s.Bind.Send(bufs, ep)
+}
+
+func (s *spyBind) drain() {
+	for {
+		select {
+		case <-s.packets:
+		default:
+			return
+		}
+	}
+}
+
+// TestKeepaliveIncludesS4Padding verifies that keepalive packets include
+// S4 transport padding, matching the kernel module (amneziawg.ko) behavior.
+//
+// The kernel module's encrypt_packet() (send.c) unconditionally prepends
+// S4 random bytes to ALL transport packets including keepalives. Before
+// the fix, awg-go's RoutineSequentialSender skipped S4 for keepalives,
+// causing the kernel module to reject them: after stripping the expected
+// S4 prefix, the remaining bytes were too short or the H4 field didn't
+// validate.
+//
+// See: https://github.com/amnezia-vpn/amneziawg-go/issues/110
+func TestKeepaliveIncludesS4Padding(t *testing.T) {
+	goroutineLeakCheck(t)
+
+	const s4 = 25
+
+	// Create spy bind on device 0 to capture raw wire packets.
+	innerBinds := bindtest.NewChannelBinds()
+	spy := newSpyBind(innerBinds[0])
+	binds := [2]conn.Bind{spy, innerBinds[1]}
+
+	cfg, endpointCfg := genConfigs(t,
+		"jc", "3",
+		"jmin", "40",
+		"jmax", "70",
+		"s1", "15",
+		"s2", "18",
+		"s3", "20",
+		"s4", "25",
+		"h1", "123456-123500",
+		"h2", "67543-67550",
+		"h3", "123123-123200",
+		"h4", "32345-32350",
+	)
+
+	// Create devices with spy bind on device 0.
+	var pair testPair
+	for i := range pair {
+		p := &pair[i]
+		p.tun = tuntest.NewChannelTUN()
+		p.ip = netip.AddrFrom4([4]byte{1, 0, 0, byte(i + 1)})
+		level := LogLevelVerbose
+		p.dev = NewDevice(p.tun.TUN(), binds[i], NewLogger(level, fmt.Sprintf("dev%d: ", i)))
+		if err := p.dev.IpcSet(cfg[i]); err != nil {
+			t.Fatalf("failed to configure device %d: %v", i, err)
+		}
+		if err := p.dev.Up(); err != nil {
+			t.Fatalf("failed to bring up device %d: %v", i, err)
+		}
+		endpointCfg[i^1] = fmt.Sprintf(endpointCfg[i^1], p.dev.net.port)
+		t.Cleanup(p.dev.Close)
+	}
+	for i := range pair {
+		if err := pair[i].dev.IpcSet(endpointCfg[i]); err != nil {
+			t.Fatalf("failed to configure device endpoint %d: %v", i, err)
+		}
+	}
+
+	// Exchange data to establish handshake and prove data flow works.
+	pair.Send(t, Ping, nil)
+	pair.Send(t, Pong, nil)
+
+	// Drain all packets from spy (handshake + junk + data).
+	// Small sleep to let any in-flight packets settle.
+	time.Sleep(100 * time.Millisecond)
+	spy.drain()
+
+	// Find peer on device 0.
+	pair[0].dev.peers.RLock()
+	var peer0 *Peer
+	for _, p := range pair[0].dev.peers.keyMap {
+		peer0 = p
+		break
+	}
+	pair[0].dev.peers.RUnlock()
+	if peer0 == nil {
+		t.Fatal("no peer found on device 0")
+	}
+
+	// Send a keepalive from device 0.
+	peer0.SendKeepalive()
+
+	// Wait for the keepalive to appear in the spy.
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case pkt := <-spy.packets:
+		// With S4 padding, the keepalive wire format is:
+		//   S4 random bytes + H4(4) + receiver(4) + counter(8) + poly1305(16)
+		//   = S4 + MessageKeepaliveSize = 25 + 32 = 57
+		// Without S4 padding (the bug), it would be just 32.
+		expectedSize := s4 + MessageKeepaliveSize
+		if len(pkt) != expectedSize {
+			t.Fatalf("keepalive packet size = %d, want %d (S4(%d) + MessageKeepaliveSize(%d))",
+				len(pkt), expectedSize, s4, MessageKeepaliveSize)
+		}
+	case <-timer.C:
+		t.Fatal("timed out waiting for keepalive packet from device 0")
+	}
+}
+
 // Needs to be stopped with Ctrl-C
 func TestAWGHandshakeDevicePing(t *testing.T) {
 	t.Skip("This test is intended to be run manually, not as part of the test suite.")

--- a/device/send.go
+++ b/device/send.go
@@ -574,16 +574,16 @@ func (peer *Peer) RoutineSequentialSender(maxBatchSize int) {
 		for _, elem := range elemsContainer.elems {
 			if len(elem.packet) != MessageKeepaliveSize {
 				dataSent = true
+			}
 
-				if padding := device.paddings.transport; padding > 0 {
-					// elem.packet is stored at the start of elem.buffer
-					// with zero padding
-					for i := len(elem.packet) - 1; i >= 0; i-- {
-						elem.buffer[i+padding] = elem.buffer[i]
-					}
-					rand.Read(elem.buffer[:padding])
-					elem.packet = elem.buffer[:padding+len(elem.packet)]
+			if padding := device.paddings.transport; padding > 0 {
+				// elem.packet is stored at the start of elem.buffer
+				// with zero padding
+				for i := len(elem.packet) - 1; i >= 0; i-- {
+					elem.buffer[i+padding] = elem.buffer[i]
 				}
+				rand.Read(elem.buffer[:padding])
+				elem.packet = elem.buffer[:padding+len(elem.packet)]
 			}
 			bufs = append(bufs, elem.packet)
 		}


### PR DESCRIPTION
@ygurov - was finally able to hunt this down, but got it working.

I reproduced my initial test.  I set the s3/4 back to non-zero values (38/22) on the server side (linux kernel).

I then tested the exact same client profile side by side on my Kubuntu laptop.. just as before:

1) Control: awg-quick (kernel) = 258/242 Mbps, healthy.
2) Linux AmneziaVPN desktop client (awg-go) = Handshake okay but no traffic passes. Tunnel dead in 28s.

After monitoring both the server and desktop client via the daemon socket (then putting Claude to work on the logs), I was able to isolate and draft fix - then retested (exact reproduction with same profie) = desktop client works!

This issue is awg-go isn't adding the s4 padding on the keepalive packets so when the server strips the expected s4 padding from the keepalive, it actually mangles the real data instead and then drops it.  The tunnel then dies soon after initial setup.

Had Claude attend to the PR writeup: 

-------
## Summary

`RoutineSequentialSender` skipped S4 padding for keepalive packets (`len(elem.packet) != MessageKeepaliveSize` guard), while the kernel module's `encrypt_packet()` ([send.c:210](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/blob/master/src/send.c#L216)) unconditionally prepends S4 random bytes to **all** transport packets including keepalives. This size mismatch caused the kernel module to reject awg-go client keepalives when S4 > 0:

1. awg-go sends a 32-byte keepalive (no S4 prefix)
2. Kernel module strips the first S4 bytes (expecting them to be random padding)
3. Remaining bytes are too short, or the H4 field at offset 0 doesn't validate
4. Keepalive is silently dropped

Without keepalives, the server-side keypair for the client never gets promoted from `next` to `current` (requires `ReceivedWithKeypair`), and the connection dies shortly after handshake.

### The fix

Move the S4 padding block outside the keepalive-size check (2 lines changed in `send.go`). The `dataSent` flag — which controls `timersDataSent()` — remains gated on the size check, preserving WireGuard timer semantics (keepalives don't trigger data-sent timers).

## Reproduction

Same laptop, same server (amneziawg.ko v1.0.20260329-2), same AWG profile (S3=38, S4=22, full STUN preset), three client implementations:

| Client | Implementation | Result |
|--------|---------------|--------|
| `awg-quick` | kernel module | 258/242 Mbps, healthy |
| AmneziaVPN 4.8.11.4 desktop | upstream awg-go | Handshake OK → 0 data → dead |
| **Patched awg-go** (this PR) | `CGO_ENABLED=0` | **Keepalives flowing, 5/5 pings, 94ms avg** |

Server-side `awg show` confirmed: upstream awg-go client transmitted 0 bytes of transport data across 4 connection attempts. Patched binary: immediate symmetric traffic flow with keepalives every 25 seconds.

<details>
<summary>Patched awg-go verbose log (keepalive cycle)</summary>

```
(awgtest0) 22:41:02 peer(sNG6…/iBs) - Sending handshake initiation
(awgtest0) 22:41:03 peer(sNG6…/iBs) - Received handshake response
(awgtest0) 22:41:03 peer(sNG6…/iBs) - Receiving keepalive packet
(awgtest0) 22:41:17 peer(sNG6…/iBs) - Sending keepalive packet
(awgtest0) 22:41:42 peer(sNG6…/iBs) - Sending keepalive packet
(awgtest0) 22:41:56 peer(sNG6…/iBs) - Sending keepalive packet
```

No "Retrying handshake" messages — connection stays alive indefinitely.
</details>

## Test coverage

Added `TestKeepaliveIncludesS4Padding`: uses a spy bind to capture raw wire packets, verifies keepalive size is exactly `S4 + MessageKeepaliveSize` (not bare `MessageKeepaliveSize`). Passes with both `CGO_ENABLED=0` and `CGO_ENABLED=1`.

## Cross-references

- Related to #110
- Related: [amnezia-client#2582](https://github.com/amnezia-vpn/amnezia-client/issues/2582) (AmneziaVPN-Android transport failure with non-zero S3/S4)
- Related: #89 (transport packet msg-type confusion)

## Acknowledgments

- @FrankBacon24 for filing #110 with the initial diagnostic analysis
- @websharik for confirming reproduction on amd64 with CGO disabled