### PR TITLE
Send prelude at endpoint session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ $ make
 ## Configuration
 
 > [!NOTE]
-> If there is no value specified (for any param), AWG treats it as 0
+> If there is no value specified (for any param), AWG treats it as 0, except `PreludeResendInterval`, which defaults to 120 seconds.
 
-### Junk packets
+### Prelude packets
 
-The amount of junk packets specified in `Jc` with a random size between `Jmin` and `Jmax` would be generated and sent prior every handshake
+Junk packets and custom signature packets are generated once at the beginning of an outbound endpoint session. They can be forced again by `PreludeResendInterval`.
 
 - `Jc: int`, recommended range is 4-12
 - `Jmin: int` <= `Jmax:int`
+- `PreludeResendInterval: int`, seconds; default is 120, explicit 0 disables timer-based resend
 
 > [!TIP]
 > Junk packets do not carry any actual data, so there is no need to specify it on both sides. General recommendation is to use it on the client side only
@@ -97,7 +98,7 @@ Values could be specified as:
 
 ### Custom signature packets
 
-These packets are being send prior to every handshake, in the same way as Junk packets do. The sending order is `I1`, `I2`, `I3`, `I4`, `I5`. If there is no value specified, the packet is skipped.
+These packets are sent as part of the prelude, in the same way as Junk packets do. The sending order is `I1`, `I2`, `I3`, `I4`, `I5`. If there is no value specified, the packet is skipped.
 
 - `I1: string`
 - `I2: string`

--- a/conceal/conn_prelude.go
+++ b/conceal/conn_prelude.go
@@ -5,15 +5,58 @@ import (
 	"math/big"
 	"net"
 	"sync"
+	"time"
 
 	"golang.org/x/net/ipv4"
 )
 
+const DefaultPreludeResendInterval = 120 * time.Second
+
 type PreludeOpts struct {
-	Jc       int
-	Jmin     int
-	Jmax     int
-	RulesArr [5]Rules
+	Jc             int
+	Jmin           int
+	Jmax           int
+	ResendInterval time.Duration
+	RulesArr       [5]Rules
+}
+
+type PreludeState struct {
+	mu       sync.Mutex
+	sent     bool
+	lastSent time.Time
+}
+
+func (s *PreludeState) ClaimSend(now time.Time, resendInterval time.Duration) bool {
+	if s == nil {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.sent {
+		s.sent = true
+		s.lastSent = now
+		return true
+	}
+
+	if resendInterval <= 0 || now.Sub(s.lastSent) < resendInterval {
+		return false
+	}
+
+	s.lastSent = now
+	return true
+}
+
+func (s *PreludeState) Reset() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	s.sent = false
+	s.lastSent = time.Time{}
+	s.mu.Unlock()
 }
 
 func (o PreludeOpts) HasDecoyRules() bool {
@@ -57,7 +100,7 @@ func NewPreludeUDPConn(
 	conn UDPConn,
 	origin UDPConn,
 	pool *sync.Pool,
-	header *RangedHeader,
+	_ *RangedHeader,
 	opts PreludeOpts,
 ) (c *PreludeUDPConn, ok bool) {
 	if opts.IsEmpty() {
@@ -69,31 +112,50 @@ func NewPreludeUDPConn(
 	}
 
 	return &PreludeUDPConn{
-		UDPConn:   conn,
-		origin:    origin,
-		pool:      WrapBufferPool(pool),
-		rulesArr:  opts.RulesArr,
-		junkCount: opts.Jc,
-		junkGen:   newJunkGenerator(opts.Jmin, opts.Jmax),
-		classifier: newPacketClassifier(FramedOpts{
-			H1:           header,
-			HeaderCompat: header != nil,
-		}),
+		UDPConn:        conn,
+		origin:         origin,
+		pool:           WrapBufferPool(pool),
+		rulesArr:       opts.RulesArr,
+		junkCount:      opts.Jc,
+		junkGen:        newJunkGenerator(opts.Jmin, opts.Jmax),
+		resendInterval: opts.ResendInterval,
 	}, true
 }
 
 type PreludeUDPConn struct {
 	UDPConn
-	origin     UDPConn
-	pool       *BufferPool
-	rulesArr   [5]Rules
-	junkCount  int
-	junkGen    *junkGenerator
-	classifier packetClassifier
+	origin         UDPConn
+	pool           *BufferPool
+	rulesArr       [5]Rules
+	junkCount      int
+	junkGen        *junkGenerator
+	statesMu       sync.Mutex
+	states         map[string]*PreludeState
+	resendInterval time.Duration
+}
+
+func (c *PreludeUDPConn) preludeState(addr net.Addr) *PreludeState {
+	key := ""
+	if addr != nil {
+		key = addr.String()
+	}
+
+	c.statesMu.Lock()
+	defer c.statesMu.Unlock()
+	if c.states == nil {
+		c.states = make(map[string]*PreludeState)
+	}
+	state := c.states[key]
+	if state == nil {
+		state = new(PreludeState)
+		c.states[key] = state
+	}
+	return state
 }
 
 func (c *PreludeUDPConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
-	if c.classifier.MatchesInitiationHeader(b) {
+	state := c.preludeState(addr)
+	if state.ClaimSend(time.Now(), c.resendInterval) {
 		buf := c.pool.Get()
 		ctx := writeContext{
 			FlexBuffer: WrapFlexBuffer(nil),
@@ -109,11 +171,13 @@ func (c *PreludeUDPConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn 
 			w.Reset(buf)
 			if err = rules.Write(&w, &ctx); err != nil {
 				c.pool.Put(buf)
+				state.Reset()
 				return 0, 0, err
 			}
 
 			if _, _, err = c.origin.WriteMsgUDP(w.Bytes(), oob, addr); err != nil {
 				c.pool.Put(buf)
+				state.Reset()
 				return 0, 0, err
 			}
 		}
@@ -122,6 +186,7 @@ func (c *PreludeUDPConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn 
 			junk := c.junkGen.generate(buf)
 			if _, _, err = c.origin.WriteMsgUDP(junk, oob, addr); err != nil {
 				c.pool.Put(buf)
+				state.Reset()
 				return 0, 0, err
 			}
 		}
@@ -138,6 +203,17 @@ func NewPreludeConn(
 	framedOpts FramedOpts,
 	opts PreludeOpts,
 ) (c *PreludeConn, ok bool) {
+	return NewPreludeConnWithState(conn, pool, framedOpts, opts, nil, false)
+}
+
+func NewPreludeConnWithState(
+	conn StreamRecordConn,
+	pool *sync.Pool,
+	framedOpts FramedOpts,
+	opts PreludeOpts,
+	state *PreludeState,
+	emitOutbound bool,
+) (c *PreludeConn, ok bool) {
 	if !opts.HasDecoyRules() || !conn.CanReadRecord() || !conn.CanWriteRecord() {
 		return nil, false
 	}
@@ -148,6 +224,9 @@ func NewPreludeConn(
 		StreamRecordConn: conn,
 		pool:             WrapBufferPool(pool),
 		rulesArr:         opts.RulesArr,
+		resendInterval:   opts.ResendInterval,
+		state:            state,
+		emitOutbound:     emitOutbound,
 		recordEncoding:   enc,
 	}, true
 }
@@ -156,15 +235,14 @@ type PreludeConn struct {
 	StreamRecordConn
 	pool           *BufferPool
 	rulesArr       [5]Rules
+	resendInterval time.Duration
+	state          *PreludeState
+	emitOutbound   bool
 	recordEncoding frameEncoding
 	seenValid      bool
 }
 
 func (c *PreludeConn) Read(b []byte) (n int, err error) {
-	if c.seenValid {
-		return c.StreamRecordConn.ReadRecord(b)
-	}
-
 	for {
 		n, err = c.StreamRecordConn.ReadRecord(b)
 		if err != nil {
@@ -191,8 +269,9 @@ func (c *PreludeConn) isPreludeRecord(b []byte) bool {
 }
 
 func (c *PreludeConn) Write(b []byte) (n int, err error) {
-	if c.recordEncoding.IsInitiationRecord(b) {
+	if c.emitOutbound && c.state != nil && c.state.ClaimSend(time.Now(), c.resendInterval) {
 		if err := c.writePreludeRecords(); err != nil {
+			c.state.Reset()
 			return 0, err
 		}
 	}
@@ -234,7 +313,7 @@ func NewPreludeBatchConn(
 	origin BatchConn,
 	bufPool *sync.Pool,
 	msgsPool *sync.Pool,
-	header *RangedHeader,
+	_ *RangedHeader,
 	opts PreludeOpts,
 ) (c *PreludeBatchConn, ok bool) {
 	if opts.IsEmpty() {
@@ -246,40 +325,57 @@ func NewPreludeBatchConn(
 	}
 
 	return &PreludeBatchConn{
-		BatchConn: conn,
-		origin:    origin,
-		bufPool:   WrapBufferPool(bufPool),
-		msgsPool:  msgsPool,
-		rulesArr:  opts.RulesArr,
-		junkCount: opts.Jc,
-		junkGen:   newJunkGenerator(opts.Jmin, opts.Jmax),
-		classifier: newPacketClassifier(FramedOpts{
-			H1:           header,
-			HeaderCompat: header != nil,
-		}),
+		BatchConn:      conn,
+		origin:         origin,
+		bufPool:        WrapBufferPool(bufPool),
+		msgsPool:       msgsPool,
+		rulesArr:       opts.RulesArr,
+		junkCount:      opts.Jc,
+		junkGen:        newJunkGenerator(opts.Jmin, opts.Jmax),
+		resendInterval: opts.ResendInterval,
 	}, true
 }
 
 type PreludeBatchConn struct {
 	BatchConn
-	origin     BatchConn
-	bufPool    *BufferPool
-	msgsPool   *sync.Pool
-	rulesArr   [5]Rules
-	junkCount  int
-	junkGen    *junkGenerator
-	classifier packetClassifier
+	origin         BatchConn
+	bufPool        *BufferPool
+	msgsPool       *sync.Pool
+	rulesArr       [5]Rules
+	junkCount      int
+	junkGen        *junkGenerator
+	statesMu       sync.Mutex
+	states         map[string]*PreludeState
+	resendInterval time.Duration
+}
+
+func (c *PreludeBatchConn) preludeState(addr net.Addr) *PreludeState {
+	key := ""
+	if addr != nil {
+		key = addr.String()
+	}
+
+	c.statesMu.Lock()
+	defer c.statesMu.Unlock()
+	if c.states == nil {
+		c.states = make(map[string]*PreludeState)
+	}
+	state := c.states[key]
+	if state == nil {
+		state = new(PreludeState)
+		c.states[key] = state
+	}
+	return state
 }
 
 func (c *PreludeBatchConn) WriteBatch(ms []ipv4.Message, flags int) (n int, err error) {
-	var initMsg *ipv4.Message
-	for i := range ms {
-		if c.classifier.MatchesInitiationHeader(ms[i].Buffers[0]) {
-			initMsg = &ms[i]
-		}
+	if len(ms) == 0 {
+		return c.BatchConn.WriteBatch(ms, flags)
 	}
 
-	if initMsg != nil {
+	preludeMsg := &ms[0]
+	state := c.preludeState(preludeMsg.Addr)
+	if state.ClaimSend(time.Now(), c.resendInterval) {
 		ctx := writeContext{
 			FlexBuffer: WrapFlexBuffer(nil),
 			BufferPool: c.bufPool,
@@ -315,12 +411,13 @@ func (c *PreludeBatchConn) WriteBatch(ms []ipv4.Message, flags int) (n int, err 
 					c.bufPool.Put(pooledBuf)
 				}
 				c.msgsPool.Put(msgs)
+				state.Reset()
 				return 0, err
 			}
 
 			(*msgs)[i].Buffers[0] = w.Bytes()
-			(*msgs)[i].OOB = initMsg.OOB
-			(*msgs)[i].Addr = initMsg.Addr
+			(*msgs)[i].OOB = preludeMsg.OOB
+			(*msgs)[i].Addr = preludeMsg.Addr
 			i++
 		}
 
@@ -329,8 +426,8 @@ func (c *PreludeBatchConn) WriteBatch(ms []ipv4.Message, flags int) (n int, err 
 			pooled = append(pooled, buf)
 
 			(*msgs)[i].Buffers[0] = c.junkGen.generate(buf)
-			(*msgs)[i].OOB = initMsg.OOB
-			(*msgs)[i].Addr = initMsg.Addr
+			(*msgs)[i].OOB = preludeMsg.OOB
+			(*msgs)[i].Addr = preludeMsg.Addr
 			i++
 		}
 
@@ -343,6 +440,7 @@ func (c *PreludeBatchConn) WriteBatch(ms []ipv4.Message, flags int) (n int, err 
 					c.bufPool.Put(pooledBuf)
 				}
 				c.msgsPool.Put(msgs)
+				state.Reset()
 				return 0, err
 			}
 			if n == len(m) {

--- a/conceal/conn_prelude.go
+++ b/conceal/conn_prelude.go
@@ -129,32 +129,12 @@ type PreludeUDPConn struct {
 	rulesArr       [5]Rules
 	junkCount      int
 	junkGen        *junkGenerator
-	statesMu       sync.Mutex
-	states         map[string]*PreludeState
+	state          PreludeState
 	resendInterval time.Duration
 }
 
-func (c *PreludeUDPConn) preludeState(addr net.Addr) *PreludeState {
-	key := ""
-	if addr != nil {
-		key = addr.String()
-	}
-
-	c.statesMu.Lock()
-	defer c.statesMu.Unlock()
-	if c.states == nil {
-		c.states = make(map[string]*PreludeState)
-	}
-	state := c.states[key]
-	if state == nil {
-		state = new(PreludeState)
-		c.states[key] = state
-	}
-	return state
-}
-
 func (c *PreludeUDPConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
-	state := c.preludeState(addr)
+	state := &c.state
 	if state.ClaimSend(time.Now(), c.resendInterval) {
 		buf := c.pool.Get()
 		ctx := writeContext{
@@ -344,28 +324,8 @@ type PreludeBatchConn struct {
 	rulesArr       [5]Rules
 	junkCount      int
 	junkGen        *junkGenerator
-	statesMu       sync.Mutex
-	states         map[string]*PreludeState
+	state          PreludeState
 	resendInterval time.Duration
-}
-
-func (c *PreludeBatchConn) preludeState(addr net.Addr) *PreludeState {
-	key := ""
-	if addr != nil {
-		key = addr.String()
-	}
-
-	c.statesMu.Lock()
-	defer c.statesMu.Unlock()
-	if c.states == nil {
-		c.states = make(map[string]*PreludeState)
-	}
-	state := c.states[key]
-	if state == nil {
-		state = new(PreludeState)
-		c.states[key] = state
-	}
-	return state
 }
 
 func (c *PreludeBatchConn) WriteBatch(ms []ipv4.Message, flags int) (n int, err error) {
@@ -374,7 +334,7 @@ func (c *PreludeBatchConn) WriteBatch(ms []ipv4.Message, flags int) (n int, err 
 	}
 
 	preludeMsg := &ms[0]
-	state := c.preludeState(preludeMsg.Addr)
+	state := &c.state
 	if state.ClaimSend(time.Now(), c.resendInterval) {
 		ctx := writeContext{
 			FlexBuffer: WrapFlexBuffer(nil),

--- a/conceal/udp_datagram_pipeline.go
+++ b/conceal/udp_datagram_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"sync"
+	"time"
 )
 
 // UDPDatagramPipeline applies UDP conceal transforms at datagram boundaries.
@@ -19,10 +20,11 @@ type UDPDatagramPipeline struct {
 	masquerade       masqueradeEncoding
 	masqueradeActive bool
 
-	preludeActive bool
-	rulesArr      [5]Rules
-	junkCount     int
-	junkGen       *junkGenerator
+	preludeActive         bool
+	preludeResendInterval time.Duration
+	rulesArr              [5]Rules
+	junkCount             int
+	junkGen               *junkGenerator
 }
 
 func NewUDPDatagramPipeline(
@@ -36,11 +38,12 @@ func NewUDPDatagramPipeline(
 	}
 
 	pipeline := &UDPDatagramPipeline{
-		pool:          WrapBufferPool(pool),
-		classifier:    newPacketClassifier(framedOpts),
-		preludeActive: !preludeOpts.IsEmpty(),
-		rulesArr:      preludeOpts.RulesArr,
-		junkCount:     preludeOpts.Jc,
+		pool:                  WrapBufferPool(pool),
+		classifier:            newPacketClassifier(framedOpts),
+		preludeActive:         !preludeOpts.IsEmpty(),
+		preludeResendInterval: preludeOpts.ResendInterval,
+		rulesArr:              preludeOpts.RulesArr,
+		junkCount:             preludeOpts.Jc,
 	}
 
 	if pipeline.junkCount > 0 {
@@ -55,6 +58,14 @@ func NewUDPDatagramPipeline(
 
 func (p *UDPDatagramPipeline) Active() bool {
 	return p.preludeActive || p.framingActive || p.masqueradeActive
+}
+
+func (p *UDPDatagramPipeline) PreludeActive() bool {
+	return p.preludeActive
+}
+
+func (p *UDPDatagramPipeline) PreludeResendInterval() time.Duration {
+	return p.preludeResendInterval
 }
 
 func (p *UDPDatagramPipeline) Encode(dst, src []byte) (int, error) {
@@ -117,8 +128,8 @@ func (p *UDPDatagramPipeline) DecodeInPlaceErr(buf []byte, n int) (int, error) {
 	return n, nil
 }
 
-func (p *UDPDatagramPipeline) EmitPrelude(packet []byte, emit func([]byte) error) error {
-	if !p.preludeActive || !p.classifier.MatchesInitiationHeader(packet) {
+func (p *UDPDatagramPipeline) EmitPrelude(emit func([]byte) error) error {
+	if !p.preludeActive {
 		return nil
 	}
 

--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -96,7 +96,8 @@ type StdNetEndpoint struct {
 	// src is the current sticky source address and interface index, if
 	// supported. Typically this is a PKTINFO structure from/for control
 	// messages, see unix.PKTINFO for an example.
-	src []byte
+	src     []byte
+	prelude conceal.PreludeState
 }
 
 var (
@@ -119,6 +120,15 @@ func (e *StdNetEndpoint) ClearSrc() {
 		// Truncate src, no need to reallocate.
 		e.src = e.src[:0]
 	}
+	e.ResetPreludeState()
+}
+
+func (e *StdNetEndpoint) PreludeState() *conceal.PreludeState {
+	return &e.prelude
+}
+
+func (e *StdNetEndpoint) ResetPreludeState() {
+	e.prelude.Reset()
 }
 
 func (e *StdNetEndpoint) DstIP() netip.Addr {

--- a/conn/bind_stream.go
+++ b/conn/bind_stream.go
@@ -113,7 +113,7 @@ func (b *BindStream) accept(listener net.Listener) {
 			// log this error somewhere
 			break
 		}
-		conn := b.upgradeConn(rawConn)
+		conn := b.upgradeConn(rawConn, nil, false)
 
 		b.wg.Add(1)
 		go b.handleAccepted(rawConn, conn)
@@ -129,9 +129,10 @@ func (b *BindStream) handleAccepted(rawConn, conn net.Conn) {
 	}
 
 	ep := &streamEndpoint{
-		conn:    conn,
-		rawConn: rawConn,
-		dst:     ap,
+		conn:            conn,
+		rawConn:         rawConn,
+		dst:             ap,
+		outboundPrelude: false,
 	}
 
 	b.wg.Add(1)
@@ -154,7 +155,8 @@ func (b *BindStream) dial(ep *streamEndpoint) error {
 		return fmt.Errorf("failed to dial context: %v", err)
 	}
 
-	conn := b.upgradeConn(rawConn)
+	ep.ResetPreludeState()
+	conn := b.upgradeConn(rawConn, ep.PreludeState(), ep.outboundPrelude)
 	ep.conn = conn
 	ep.rawConn = rawConn
 
@@ -255,7 +257,8 @@ func (b *BindStream) ParseEndpoint(s string) (Endpoint, error) {
 	}
 
 	return &streamEndpoint{
-		dst: tcpAddr.AddrPort(),
+		dst:             tcpAddr.AddrPort(),
+		outboundPrelude: true,
 	}, nil
 }
 
@@ -269,8 +272,10 @@ type streamEndpoint struct {
 	conn    net.Conn
 	rawConn net.Conn
 
-	dst   netip.AddrPort
-	mutex sync.Mutex
+	dst             netip.AddrPort
+	prelude         conceal.PreludeState
+	outboundPrelude bool
+	mutex           sync.Mutex
 }
 
 func (e *streamEndpoint) Close() {
@@ -285,6 +290,7 @@ func (e *streamEndpoint) Close() {
 		e.rawConn.Close()
 		e.rawConn = nil
 	}
+	e.ResetPreludeState()
 }
 
 func (e *streamEndpoint) DstToString() string {
@@ -301,6 +307,15 @@ func (e *streamEndpoint) DstIP() netip.Addr {
 }
 
 func (e *streamEndpoint) ClearSrc() {
+	e.ResetPreludeState()
+}
+
+func (e *streamEndpoint) PreludeState() *conceal.PreludeState {
+	return &e.prelude
+}
+
+func (e *streamEndpoint) ResetPreludeState() {
+	e.prelude.Reset()
 }
 
 func (e *streamEndpoint) SrcToString() string {

--- a/conn/conceal.go
+++ b/conn/conceal.go
@@ -167,7 +167,7 @@ func (b *StdNetBind) SetFallbackPort(port uint16) {
 	b.fallbackPort = port
 }
 
-func (b *BindStream) upgradeConn(conn net.Conn) net.Conn {
+func (b *BindStream) upgradeConn(conn net.Conn, preludeState *conceal.PreludeState, emitPrelude bool) net.Conn {
 	var recordConn conceal.StreamRecordConn
 	for _, stage := range b.streamConcealPipeline().stages {
 		switch stage {
@@ -177,7 +177,7 @@ func (b *BindStream) upgradeConn(conn net.Conn) net.Conn {
 				conn = masquerade
 			}
 		case concealStagePrelude:
-			if prelude, ok := conceal.NewPreludeConn(recordConn, &b.bufferPool, b.framedOpts, b.preludeOpts); ok {
+			if prelude, ok := conceal.NewPreludeConnWithState(recordConn, &b.bufferPool, b.framedOpts, b.preludeOpts, preludeState, emitPrelude); ok {
 				conn = prelude
 			}
 		case concealStageFramed:

--- a/conn/conceal_pipeline_test.go
+++ b/conn/conceal_pipeline_test.go
@@ -112,13 +112,13 @@ func TestBindStreamPipelineOmitsPreludeForTCPJunkOnlyConfig(t *testing.T) {
 	}
 }
 
-func TestBindStreamTCPPreludeInjectsBeforeEveryInitiation(t *testing.T) {
+func TestBindStreamTCPPreludeInjectsOncePerSession(t *testing.T) {
 	senderRaw, receiverRaw := net.Pipe()
 	defer senderRaw.Close()
 	defer receiverRaw.Close()
 
 	bind := newRecordAwareBind(t)
-	sender := bind.upgradeConn(senderRaw)
+	sender := upgradeTestStreamConn(bind, senderRaw, true)
 	receiver := mustRecordConn(t, receiverRaw, &bind.bufferPool, conceal.MasqueradeOpts{
 		RulesIn: mustParseRules(t, "<dz be 2><d>"),
 	})
@@ -151,11 +151,6 @@ func TestBindStreamTCPPreludeInjectsBeforeEveryInitiation(t *testing.T) {
 		writeErr <- err
 	}()
 
-	secondPrelude := readRecord(t, receiver, 16)
-	if !bytes.Equal(secondPrelude, []byte{0xaa, 0xbb}) {
-		t.Fatalf("second prelude record = %x, want aabb", secondPrelude)
-	}
-
 	secondInit := readRecord(t, receiver, len(initiation))
 	if gotHeader := binary.LittleEndian.Uint32(secondInit[:4]); gotHeader != 777 {
 		t.Fatalf("second initiation header = %d, want 777", gotHeader)
@@ -166,13 +161,13 @@ func TestBindStreamTCPPreludeInjectsBeforeEveryInitiation(t *testing.T) {
 	}
 }
 
-func TestBindStreamTCPPreludeSkipsNonInitiationRecords(t *testing.T) {
+func TestBindStreamTCPPreludeInjectsBeforeFirstOutboundRecord(t *testing.T) {
 	senderRaw, receiverRaw := net.Pipe()
 	defer senderRaw.Close()
 	defer receiverRaw.Close()
 
 	bind := newRecordAwareBind(t)
-	sender := bind.upgradeConn(senderRaw)
+	sender := upgradeTestStreamConn(bind, senderRaw, true)
 	receiver := mustRecordConn(t, receiverRaw, &bind.bufferPool, conceal.MasqueradeOpts{
 		RulesIn: mustParseRules(t, "<dz be 2><d>"),
 	})
@@ -183,6 +178,11 @@ func TestBindStreamTCPPreludeSkipsNonInitiationRecords(t *testing.T) {
 		_, err := sender.Write(transport)
 		writeErr <- err
 	}()
+
+	prelude := readRecord(t, receiver, 16)
+	if !bytes.Equal(prelude, []byte{0xaa, 0xbb}) {
+		t.Fatalf("prelude record = %x, want aabb", prelude)
+	}
 
 	gotTransport := readRecord(t, receiver, len(transport))
 	if gotHeader := binary.LittleEndian.Uint32(gotTransport[:4]); gotHeader != 779 {
@@ -209,8 +209,8 @@ func TestBindStreamTCPPreludeDropsInjectedDecoysOnRead(t *testing.T) {
 	defer receiverRaw.Close()
 
 	bind := newRecordAwareBind(t)
-	sender := bind.upgradeConn(senderRaw)
-	receiver := bind.upgradeConn(receiverRaw)
+	sender := upgradeTestStreamConn(bind, senderRaw, true)
+	receiver := upgradeTestStreamConn(bind, receiverRaw, false)
 
 	initiation := makeInitiationPacket()
 	writeErr := make(chan error, 1)
@@ -235,7 +235,7 @@ func TestBindStreamTCPPreludeRejectsLeadingUnknownRecords(t *testing.T) {
 	defer receiverRaw.Close()
 
 	bind := newRecordAwareBind(t)
-	receiver := bind.upgradeConn(receiverRaw)
+	receiver := upgradeTestStreamConn(bind, receiverRaw, false)
 
 	recordWriter := mustRecordConn(t, senderRaw, &bind.bufferPool, conceal.MasqueradeOpts{
 		RulesOut: mustParseRules(t, "<dz be 2><d>"),
@@ -263,8 +263,8 @@ func TestBindStreamTCPPreludePassesResponseAndTransportRecords(t *testing.T) {
 	defer receiverRaw.Close()
 
 	bind := newRecordAwareBind(t)
-	sender := bind.upgradeConn(senderRaw)
-	receiver := bind.upgradeConn(receiverRaw)
+	sender := upgradeTestStreamConn(bind, senderRaw, false)
+	receiver := upgradeTestStreamConn(bind, receiverRaw, false)
 
 	response := makeResponsePacket()
 	sendAndAssertRoundTrip(t, sender, receiver, response)
@@ -296,6 +296,14 @@ func newRecordAwareBind(t *testing.T) *BindStream {
 		},
 	})
 	return bind
+}
+
+func upgradeTestStreamConn(bind *BindStream, conn net.Conn, emitPrelude bool) net.Conn {
+	var state *conceal.PreludeState
+	if emitPrelude {
+		state = new(conceal.PreludeState)
+	}
+	return bind.upgradeConn(conn, state, emitPrelude)
 }
 
 func sendAndAssertRoundTrip(t *testing.T, sender, receiver net.Conn, packet []byte) {

--- a/conn/prelude.go
+++ b/conn/prelude.go
@@ -7,3 +7,56 @@ type PreludeEndpoint interface {
 	PreludeState() *conceal.PreludeState
 	ResetPreludeState()
 }
+
+type wrappedEndpoint interface {
+	Endpoint
+	UnwrapEndpoint() Endpoint
+}
+
+type preludeEndpoint struct {
+	Endpoint
+	prelude conceal.PreludeState
+}
+
+func wrapPreludeEndpoint(ep Endpoint) Endpoint {
+	if ep == nil {
+		return nil
+	}
+	if _, ok := ep.(PreludeEndpoint); ok {
+		return ep
+	}
+	if _, ok := ep.(wrappedEndpoint); ok {
+		return ep
+	}
+	return &preludeEndpoint{Endpoint: ep}
+}
+
+func unwrapEndpoint(ep Endpoint) Endpoint {
+	for {
+		wrapped, ok := ep.(wrappedEndpoint)
+		if !ok {
+			return ep
+		}
+		ep = wrapped.UnwrapEndpoint()
+	}
+}
+
+func (e *preludeEndpoint) UnwrapEndpoint() Endpoint {
+	return e.Endpoint
+}
+
+func (e *preludeEndpoint) ClearSrc() {
+	e.Endpoint.ClearSrc()
+	e.ResetPreludeState()
+}
+
+func (e *preludeEndpoint) PreludeState() *conceal.PreludeState {
+	return &e.prelude
+}
+
+func (e *preludeEndpoint) ResetPreludeState() {
+	e.prelude.Reset()
+}
+
+var _ PreludeEndpoint = (*preludeEndpoint)(nil)
+var _ wrappedEndpoint = (*preludeEndpoint)(nil)

--- a/conn/prelude.go
+++ b/conn/prelude.go
@@ -1,0 +1,9 @@
+package conn
+
+import "github.com/amnezia-vpn/amneziawg-go/conceal"
+
+type PreludeEndpoint interface {
+	Endpoint
+	PreludeState() *conceal.PreludeState
+	ResetPreludeState()
+}

--- a/conn/udp_conceal_bind.go
+++ b/conn/udp_conceal_bind.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/amnezia-vpn/amneziawg-go/conceal"
 )
@@ -31,6 +32,7 @@ type ConcealBind struct {
 	fallbackPort   uint16
 
 	fallbackSessions map[string]*concealBindFallbackSession
+	preludeStates    map[string]*conceal.PreludeState
 
 	pipeline atomic.Pointer[conceal.UDPDatagramPipeline]
 }
@@ -129,7 +131,50 @@ func (b *ConcealBind) SetMark(mark uint32) error {
 	return b.inner.SetMark(mark)
 }
 
+func (b *ConcealBind) preludeState(ep Endpoint) *conceal.PreludeState {
+	if ep == nil {
+		return nil
+	}
+	if preludeEP, ok := ep.(PreludeEndpoint); ok {
+		return preludeEP.PreludeState()
+	}
+
+	key := ep.DstToString()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.preludeStates == nil {
+		b.preludeStates = make(map[string]*conceal.PreludeState)
+	}
+	state := b.preludeStates[key]
+	if state == nil {
+		state = new(conceal.PreludeState)
+		b.preludeStates[key] = state
+	}
+	return state
+}
+
+func (b *ConcealBind) resetPreludeState(ep Endpoint) {
+	if ep == nil {
+		return
+	}
+	if preludeEP, ok := ep.(PreludeEndpoint); ok {
+		preludeEP.ResetPreludeState()
+		return
+	}
+
+	key := ep.DstToString()
+	b.mu.Lock()
+	if state := b.preludeStates[key]; state != nil {
+		state.Reset()
+	}
+	b.mu.Unlock()
+}
+
 func (b *ConcealBind) Send(bufs [][]byte, ep Endpoint) error {
+	if len(bufs) == 0 {
+		return nil
+	}
+
 	pipeline := b.currentPipeline()
 	if pipeline == nil || !pipeline.Active() {
 		return b.inner.Send(bufs, ep)
@@ -192,13 +237,17 @@ func (b *ConcealBind) Send(bufs [][]byte, ep Endpoint) error {
 		return nil
 	}
 
-	for _, buf := range bufs {
-		if err := pipeline.EmitPrelude(buf, func(packet []byte) error {
+	preludeState := b.preludeState(ep)
+	if pipeline.PreludeActive() && preludeState != nil && preludeState.ClaimSend(time.Now(), pipeline.PreludeResendInterval()) {
+		if err := pipeline.EmitPrelude(func(packet []byte) error {
 			return appendPacket(bytes.Clone(packet), nil)
 		}); err != nil {
+			b.resetPreludeState(ep)
 			return err
 		}
+	}
 
+	for _, buf := range bufs {
 		encoded := b.bufPool.Get().([]byte)
 		n, err := pipeline.Encode(encoded, buf)
 		if err != nil {
@@ -214,7 +263,12 @@ func (b *ConcealBind) Send(bufs [][]byte, ep Endpoint) error {
 }
 
 func (b *ConcealBind) ParseEndpoint(s string) (Endpoint, error) {
-	return b.inner.ParseEndpoint(s)
+	ep, err := b.inner.ParseEndpoint(s)
+	if err != nil {
+		return nil, err
+	}
+	b.resetPreludeState(ep)
+	return ep, nil
 }
 
 func (b *ConcealBind) BatchSize() int {

--- a/conn/udp_conceal_bind.go
+++ b/conn/udp_conceal_bind.go
@@ -32,7 +32,6 @@ type ConcealBind struct {
 	fallbackPort   uint16
 
 	fallbackSessions map[string]*concealBindFallbackSession
-	preludeStates    map[string]*conceal.PreludeState
 
 	pipeline atomic.Pointer[conceal.UDPDatagramPipeline]
 }
@@ -90,6 +89,7 @@ func (b *ConcealBind) wrapReceiveFunc(fn ReceiveFunc) ReceiveFunc {
 
 		pipeline := b.currentPipeline()
 		if pipeline == nil || !pipeline.Active() {
+			wrapPreludeEndpoints(eps[:n])
 			return n, nil
 		}
 
@@ -115,8 +115,15 @@ func (b *ConcealBind) wrapReceiveFunc(fn ReceiveFunc) ReceiveFunc {
 			}
 
 			sizes[i] = size
+			eps[i] = wrapPreludeEndpoint(eps[i])
 		}
 		return n, nil
+	}
+}
+
+func wrapPreludeEndpoints(eps []Endpoint) {
+	for i, ep := range eps {
+		eps[i] = wrapPreludeEndpoint(ep)
 	}
 }
 
@@ -138,19 +145,7 @@ func (b *ConcealBind) preludeState(ep Endpoint) *conceal.PreludeState {
 	if preludeEP, ok := ep.(PreludeEndpoint); ok {
 		return preludeEP.PreludeState()
 	}
-
-	key := ep.DstToString()
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.preludeStates == nil {
-		b.preludeStates = make(map[string]*conceal.PreludeState)
-	}
-	state := b.preludeStates[key]
-	if state == nil {
-		state = new(conceal.PreludeState)
-		b.preludeStates[key] = state
-	}
-	return state
+	return nil
 }
 
 func (b *ConcealBind) resetPreludeState(ep Endpoint) {
@@ -159,15 +154,7 @@ func (b *ConcealBind) resetPreludeState(ep Endpoint) {
 	}
 	if preludeEP, ok := ep.(PreludeEndpoint); ok {
 		preludeEP.ResetPreludeState()
-		return
 	}
-
-	key := ep.DstToString()
-	b.mu.Lock()
-	if state := b.preludeStates[key]; state != nil {
-		state.Reset()
-	}
-	b.mu.Unlock()
 }
 
 func (b *ConcealBind) Send(bufs [][]byte, ep Endpoint) error {
@@ -177,7 +164,7 @@ func (b *ConcealBind) Send(bufs [][]byte, ep Endpoint) error {
 
 	pipeline := b.currentPipeline()
 	if pipeline == nil || !pipeline.Active() {
-		return b.inner.Send(bufs, ep)
+		return b.inner.Send(bufs, unwrapEndpoint(ep))
 	}
 
 	batchSize := b.inner.BatchSize()
@@ -210,7 +197,7 @@ func (b *ConcealBind) Send(bufs [][]byte, ep Endpoint) error {
 		if len(batch) == 0 {
 			return nil
 		}
-		err := b.inner.Send(batch, ep)
+		err := b.inner.Send(batch, unwrapEndpoint(ep))
 		putRetained()
 		clearBatch()
 		return err
@@ -267,6 +254,7 @@ func (b *ConcealBind) ParseEndpoint(s string) (Endpoint, error) {
 	if err != nil {
 		return nil, err
 	}
+	ep = wrapPreludeEndpoint(ep)
 	b.resetPreludeState(ep)
 	return ep, nil
 }
@@ -411,7 +399,7 @@ func (s *concealBindFallbackSession) relay() {
 		if err != nil {
 			return
 		}
-		if err := s.parent.inner.Send([][]byte{buf[:n]}, s.ep); err != nil {
+		if err := s.parent.inner.Send([][]byte{buf[:n]}, unwrapEndpoint(s.ep)); err != nil {
 			return
 		}
 	}

--- a/conn/udp_conceal_bind_test.go
+++ b/conn/udp_conceal_bind_test.go
@@ -92,6 +92,29 @@ func TestConcealBindNoOpWithoutOpts(t *testing.T) {
 	}
 }
 
+func TestConcealBindNoOpUnwrapsNonPreludeEndpoint(t *testing.T) {
+	inner := &rawPacketBind{
+		fakePacketBind: fakePacketBind{batchSize: 3},
+	}
+	bind := NewConcealBind(inner)
+
+	endpoint, err := bind.ParseEndpoint("127.0.0.1:51820")
+	if err != nil {
+		t.Fatalf("parse endpoint: %v", err)
+	}
+	if _, ok := endpoint.(PreludeEndpoint); !ok {
+		t.Fatalf("parsed endpoint does not carry prelude state")
+	}
+
+	transport := makeTransportPacket()
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if inner.badEndpoint {
+		t.Fatalf("inner bind received wrapped endpoint, want raw endpoint")
+	}
+}
+
 func TestConcealBindSendBatchesActivePipeline(t *testing.T) {
 	inner := &fakePacketBind{batchSize: 3}
 	bind := NewConcealBind(inner)
@@ -265,6 +288,52 @@ func TestConcealBindPreludePositiveResendIntervalForcesResend(t *testing.T) {
 	}
 	if got := wireHeader(t, wirePackets[3]); got != 779 {
 		t.Fatalf("second transport header = %d, want 779", got)
+	}
+}
+
+func TestConcealBindWrapsNonPreludeEndpointAndUnwrapsForInnerBind(t *testing.T) {
+	inner := &rawPacketBind{
+		fakePacketBind: fakePacketBind{batchSize: 8},
+	}
+	bind := NewConcealBind(inner)
+	bind.SetFramedOpts(conceal.FramedOpts{H4: mustHeader(t, "779")})
+	bind.SetPreludeOpts(conceal.PreludeOpts{
+		ResendInterval: 0,
+		RulesArr: [5]conceal.Rules{
+			mustParseRules(t, "<b 0xaabb>"),
+		},
+	})
+
+	endpoint, err := bind.ParseEndpoint("127.0.0.1:51820")
+	if err != nil {
+		t.Fatalf("parse endpoint: %v", err)
+	}
+	if _, ok := endpoint.(PreludeEndpoint); !ok {
+		t.Fatalf("parsed endpoint does not carry prelude state")
+	}
+
+	transport := makeTransportPacket()
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+	if inner.badEndpoint {
+		t.Fatalf("inner bind received wrapped endpoint, want raw endpoint")
+	}
+
+	wirePackets := flattenSendCalls(inner.sendCalls)
+	if len(wirePackets) != 3 {
+		t.Fatalf("wire packet count = %d, want 3", len(wirePackets))
+	}
+	if !bytes.Equal(wirePackets[0], []byte{0xaa, 0xbb}) {
+		t.Fatalf("wire prelude = %x, want aabb", wirePackets[0])
+	}
+	for i, call := range inner.sendCalls {
+		if _, ok := call.endpoint.(*rawPacketEndpoint); !ok {
+			t.Fatalf("send call %d endpoint = %T, want *rawPacketEndpoint", i, call.endpoint)
+		}
 	}
 }
 
@@ -665,6 +734,53 @@ func (e *fakePacketEndpoint) SrcIP() netip.Addr {
 	return netip.Addr{}
 }
 
+type rawPacketBind struct {
+	fakePacketBind
+	badEndpoint bool
+}
+
+func (b *rawPacketBind) Send(bufs [][]byte, ep Endpoint) error {
+	if _, ok := ep.(*rawPacketEndpoint); !ok {
+		b.badEndpoint = true
+	}
+	return b.fakePacketBind.Send(bufs, ep)
+}
+
+func (b *rawPacketBind) ParseEndpoint(s string) (Endpoint, error) {
+	addr, err := netip.ParseAddrPort(s)
+	if err != nil {
+		return nil, err
+	}
+	return &rawPacketEndpoint{addr: addr}, nil
+}
+
+type rawPacketEndpoint struct {
+	addr netip.AddrPort
+}
+
+func (e *rawPacketEndpoint) ClearSrc() {}
+
+func (e *rawPacketEndpoint) SrcToString() string {
+	return ""
+}
+
+func (e *rawPacketEndpoint) DstToString() string {
+	return e.addr.String()
+}
+
+func (e *rawPacketEndpoint) DstToBytes() []byte {
+	out, _ := e.addr.MarshalBinary()
+	return out
+}
+
+func (e *rawPacketEndpoint) DstIP() netip.Addr {
+	return e.addr.Addr()
+}
+
+func (e *rawPacketEndpoint) SrcIP() netip.Addr {
+	return netip.Addr{}
+}
+
 func flattenSendCalls(calls []fakeSendCall) [][]byte {
 	var out [][]byte
 	for _, call := range calls {
@@ -691,5 +807,7 @@ func wireHeader(t *testing.T, packet []byte) uint32 {
 }
 
 var _ Bind = (*fakePacketBind)(nil)
+var _ Bind = (*rawPacketBind)(nil)
 var _ Endpoint = (*fakePacketEndpoint)(nil)
+var _ Endpoint = (*rawPacketEndpoint)(nil)
 var _ PreludeEndpoint = (*fakePacketEndpoint)(nil)

--- a/conn/udp_conceal_bind_test.go
+++ b/conn/udp_conceal_bind_test.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/amnezia-vpn/amneziawg-go/conceal"
 )
@@ -159,13 +160,13 @@ func TestConcealBindSendBatchesPreludeInWireOrder(t *testing.T) {
 		t.Fatalf("send: %v", err)
 	}
 
-	if got := sendCallBatchLengths(inner.sendCalls); !slices.Equal(got, []int{3, 3, 1}) {
-		t.Fatalf("send batch lengths = %v, want [3 3 1]", got)
+	if got := sendCallBatchLengths(inner.sendCalls); !slices.Equal(got, []int{3, 2}) {
+		t.Fatalf("send batch lengths = %v, want [3 2]", got)
 	}
 
 	wirePackets := flattenSendCalls(inner.sendCalls)
-	if len(wirePackets) != 7 {
-		t.Fatalf("wire packet count = %d, want 7", len(wirePackets))
+	if len(wirePackets) != 5 {
+		t.Fatalf("wire packet count = %d, want 5", len(wirePackets))
 	}
 	if !bytes.Equal(wirePackets[0], []byte{0xaa, 0xbb}) {
 		t.Fatalf("wire packet 0 prelude = %x, want aabb", wirePackets[0])
@@ -179,14 +180,91 @@ func TestConcealBindSendBatchesPreludeInWireOrder(t *testing.T) {
 	if got := wireHeader(t, wirePackets[3]); got != 779 {
 		t.Fatalf("wire packet 3 header = %d, want 779", got)
 	}
-	if !bytes.Equal(wirePackets[4], []byte{0xaa, 0xbb}) {
-		t.Fatalf("wire packet 4 prelude = %x, want aabb", wirePackets[4])
+	if got := wireHeader(t, wirePackets[4]); got != 777 {
+		t.Fatalf("wire packet 4 header = %d, want 777", got)
 	}
-	if len(wirePackets[5]) != 3 {
-		t.Fatalf("wire packet 5 junk len = %d, want 3", len(wirePackets[5]))
+}
+
+func TestConcealBindPreludeResendIntervalZeroDisablesForcedResend(t *testing.T) {
+	inner := &fakePacketBind{batchSize: 8}
+	bind := NewConcealBind(inner)
+	bind.SetFramedOpts(conceal.FramedOpts{H4: mustHeader(t, "779")})
+	bind.SetPreludeOpts(conceal.PreludeOpts{
+		ResendInterval: 0,
+		RulesArr: [5]conceal.Rules{
+			mustParseRules(t, "<b 0xaabb>"),
+		},
+	})
+
+	endpoint, err := bind.ParseEndpoint("127.0.0.1:51820")
+	if err != nil {
+		t.Fatalf("parse endpoint: %v", err)
 	}
-	if got := wireHeader(t, wirePackets[6]); got != 777 {
-		t.Fatalf("wire packet 6 header = %d, want 777", got)
+
+	transport := makeTransportPacket()
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+
+	wirePackets := flattenSendCalls(inner.sendCalls)
+	if len(wirePackets) != 3 {
+		t.Fatalf("wire packet count = %d, want 3", len(wirePackets))
+	}
+	if !bytes.Equal(wirePackets[0], []byte{0xaa, 0xbb}) {
+		t.Fatalf("wire prelude = %x, want aabb", wirePackets[0])
+	}
+	if got := wireHeader(t, wirePackets[1]); got != 779 {
+		t.Fatalf("first transport header = %d, want 779", got)
+	}
+	if got := wireHeader(t, wirePackets[2]); got != 779 {
+		t.Fatalf("second transport header = %d, want 779", got)
+	}
+}
+
+func TestConcealBindPreludePositiveResendIntervalForcesResend(t *testing.T) {
+	inner := &fakePacketBind{batchSize: 8}
+	bind := NewConcealBind(inner)
+	bind.SetFramedOpts(conceal.FramedOpts{H4: mustHeader(t, "779")})
+	bind.SetPreludeOpts(conceal.PreludeOpts{
+		ResendInterval: time.Nanosecond,
+		RulesArr: [5]conceal.Rules{
+			mustParseRules(t, "<b 0xaabb>"),
+		},
+	})
+
+	endpoint, err := bind.ParseEndpoint("127.0.0.1:51820")
+	if err != nil {
+		t.Fatalf("parse endpoint: %v", err)
+	}
+
+	transport := makeTransportPacket()
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if err := bind.Send([][]byte{transport}, endpoint); err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+
+	wirePackets := flattenSendCalls(inner.sendCalls)
+	if len(wirePackets) != 4 {
+		t.Fatalf("wire packet count = %d, want 4", len(wirePackets))
+	}
+	if !bytes.Equal(wirePackets[0], []byte{0xaa, 0xbb}) {
+		t.Fatalf("first prelude = %x, want aabb", wirePackets[0])
+	}
+	if got := wireHeader(t, wirePackets[1]); got != 779 {
+		t.Fatalf("first transport header = %d, want 779", got)
+	}
+	if !bytes.Equal(wirePackets[2], []byte{0xaa, 0xbb}) {
+		t.Fatalf("second prelude = %x, want aabb", wirePackets[2])
+	}
+	if got := wireHeader(t, wirePackets[3]); got != 779 {
+		t.Fatalf("second transport header = %d, want 779", got)
 	}
 }
 
@@ -550,10 +628,21 @@ func (b *fakePacketBind) BatchSize() int {
 }
 
 type fakePacketEndpoint struct {
-	addr netip.AddrPort
+	addr    netip.AddrPort
+	prelude conceal.PreludeState
 }
 
-func (e *fakePacketEndpoint) ClearSrc() {}
+func (e *fakePacketEndpoint) ClearSrc() {
+	e.ResetPreludeState()
+}
+
+func (e *fakePacketEndpoint) PreludeState() *conceal.PreludeState {
+	return &e.prelude
+}
+
+func (e *fakePacketEndpoint) ResetPreludeState() {
+	e.prelude.Reset()
+}
 
 func (e *fakePacketEndpoint) SrcToString() string {
 	return ""
@@ -603,3 +692,4 @@ func wireHeader(t *testing.T, packet []byte) uint32 {
 
 var _ Bind = (*fakePacketBind)(nil)
 var _ Endpoint = (*fakePacketEndpoint)(nil)
+var _ PreludeEndpoint = (*fakePacketEndpoint)(nil)

--- a/device/device.go
+++ b/device/device.go
@@ -307,6 +307,7 @@ func NewDevice(tunDevice tun.Device, bind conn.Bind, logger *Logger) *Device {
 
 	device.net.network = "udp"
 	device.net.framedOpts.HeaderCompat = true
+	device.net.preludeOpts.ResendInterval = conceal.DefaultPreludeResendInterval
 
 	device.PopulatePools()
 

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -110,6 +110,8 @@ func (device *Device) IpcGetOperation(w io.Writer) error {
 			sendf("jmax=%d", device.net.preludeOpts.Jmax)
 		}
 
+		sendf("prelude_resend_interval=%d", int64(device.net.preludeOpts.ResendInterval/time.Second))
+
 		if device.net.framedOpts.S1 != 0 {
 			sendf("s1=%d", device.net.framedOpts.S1)
 		}
@@ -362,6 +364,19 @@ func (device *Device) handleDeviceLine(key, value string) error {
 
 		if err := device.BindUpdate(); err != nil {
 			return ipcErrorf(ipc.IpcErrorPortInUse, "failed to set junk max: %w", err)
+		}
+
+	case "prelude_resend_interval":
+		secs, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to parse prelude_resend_interval: %w", err)
+		}
+
+		device.log.Verbosef("UAPI: Updating prelude resend interval")
+		device.net.preludeOpts.ResendInterval = time.Duration(secs) * time.Second
+
+		if err := device.BindUpdate(); err != nil {
+			return ipcErrorf(ipc.IpcErrorPortInUse, "failed to set prelude resend interval: %w", err)
 		}
 
 	case "s1":

--- a/device/uapi_fallback_test.go
+++ b/device/uapi_fallback_test.go
@@ -33,3 +33,36 @@ func TestDeviceFallbackPortUAPI(t *testing.T) {
 		}
 	}
 }
+
+func TestDevicePreludeResendIntervalUAPI(t *testing.T) {
+	tunDevice := tuntest.NewChannelTUN()
+	binds := bindtest.NewChannelBinds()
+	device := NewDevice(tunDevice.TUN(), binds[0], NewLogger(LogLevelError, ""))
+	defer device.Close()
+
+	var got bytes.Buffer
+	if err := device.IpcGetOperation(&got); err != nil {
+		t.Fatalf("get default uapi: %v", err)
+	}
+	if !strings.Contains(got.String(), "prelude_resend_interval=120\n") {
+		t.Fatalf("IpcGetOperation output missing default prelude_resend_interval: %q", got.String())
+	}
+
+	if err := device.IpcSet(uapiCfg("prelude_resend_interval", "0")); err != nil {
+		t.Fatalf("set prelude_resend_interval=0: %v", err)
+	}
+
+	got.Reset()
+	if err := device.IpcGetOperation(&got); err != nil {
+		t.Fatalf("get updated uapi: %v", err)
+	}
+	if !strings.Contains(got.String(), "prelude_resend_interval=0\n") {
+		t.Fatalf("IpcGetOperation output missing disabled prelude_resend_interval: %q", got.String())
+	}
+
+	for _, value := range []string{"-1", "abc"} {
+		if err := device.IpcSet(uapiCfg("prelude_resend_interval", value)); err == nil {
+			t.Fatalf("prelude_resend_interval=%s accepted, want error", value)
+		}
+	}
+}

--- a/outline/fallback.go
+++ b/outline/fallback.go
@@ -16,28 +16,29 @@ import (
 )
 
 type DeviceConfig struct {
-	PrivateKey   string       `yaml:"private_key"`
-	Address      []string     `yaml:"address"`
-	Dns          []string     `yaml:"dns"`
-	Mtu          int          `yaml:"mtu,omitempty"`
-	Jc           int          `yaml:"jc,omitempty"`
-	Jmin         int          `yaml:"jmin,omitempty"`
-	Jmax         int          `yaml:"jmax,omitempty"`
-	S1           int          `yaml:"s1,omitempty"`
-	S2           int          `yaml:"s2,omitempty"`
-	S3           int          `yaml:"s3,omitempty"`
-	S4           int          `yaml:"s4,omitempty"`
-	H1           string       `yaml:"h1,omitempty"`
-	H2           string       `yaml:"h2,omitempty"`
-	H3           string       `yaml:"h3,omitempty"`
-	H4           string       `yaml:"h4,omitempty"`
-	I1           string       `yaml:"i1,omitempty"`
-	I2           string       `yaml:"i2,omitempty"`
-	I3           string       `yaml:"i3,omitempty"`
-	I4           string       `yaml:"i4,omitempty"`
-	I5           string       `yaml:"i5,omitempty"`
-	FallbackPort int          `yaml:"fallback_port,omitempty"`
-	Peers        []PeerConfig `yaml:"peers,omitempty"`
+	PrivateKey            string       `yaml:"private_key"`
+	Address               []string     `yaml:"address"`
+	Dns                   []string     `yaml:"dns"`
+	Mtu                   int          `yaml:"mtu,omitempty"`
+	Jc                    int          `yaml:"jc,omitempty"`
+	Jmin                  int          `yaml:"jmin,omitempty"`
+	Jmax                  int          `yaml:"jmax,omitempty"`
+	PreludeResendInterval *int         `yaml:"prelude_resend_interval,omitempty"`
+	S1                    int          `yaml:"s1,omitempty"`
+	S2                    int          `yaml:"s2,omitempty"`
+	S3                    int          `yaml:"s3,omitempty"`
+	S4                    int          `yaml:"s4,omitempty"`
+	H1                    string       `yaml:"h1,omitempty"`
+	H2                    string       `yaml:"h2,omitempty"`
+	H3                    string       `yaml:"h3,omitempty"`
+	H4                    string       `yaml:"h4,omitempty"`
+	I1                    string       `yaml:"i1,omitempty"`
+	I2                    string       `yaml:"i2,omitempty"`
+	I3                    string       `yaml:"i3,omitempty"`
+	I4                    string       `yaml:"i4,omitempty"`
+	I5                    string       `yaml:"i5,omitempty"`
+	FallbackPort          int          `yaml:"fallback_port,omitempty"`
+	Peers                 []PeerConfig `yaml:"peers,omitempty"`
 }
 
 type PeerConfig struct {
@@ -84,6 +85,10 @@ func genIpcString(cfg *DeviceConfig) (string, error) {
 	if cfg.Jmax != 0 {
 		b.WriteString("\njmax=")
 		b.WriteString(strconv.Itoa(cfg.Jmax))
+	}
+	if cfg.PreludeResendInterval != nil {
+		b.WriteString("\nprelude_resend_interval=")
+		b.WriteString(strconv.Itoa(*cfg.PreludeResendInterval))
 	}
 	if cfg.S1 != 0 {
 		b.WriteString("\ns1=")


### PR DESCRIPTION
## Summary

Moves prelude emission from WireGuard initiation detection to endpoint/session state.

- sends `I1-I5` and `Jc/Jmin/Jmax` once at the beginning of an outbound endpoint session
- adds `PreludeResendInterval` / `prelude_resend_interval`
- defaults resend interval to 120 seconds
- treats explicit `0` as disabling timer-based resend
- resets endpoint prelude state on `ClearSrc` and new outbound TCP dial
- keeps TCP prelude outbound-only for locally initiated sessions
- updates tests and README docs for the new behavior
