### PR TITLE
feat: restore AmneziaWG 1.5 keys (j1..j3, itime, <c> tag) on top of 2.0

### DIFF
--- a/device/awg_legacy_test.go
+++ b/device/awg_legacy_test.go
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2025 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUAPILegacyJunkAndItime checks that the restored AmneziaWG 1.5 device keys
+// (j1..j3 controlled junk and itime) are accepted by the UAPI set operation,
+// stored on the device, and round-tripped by the get operation.
+func TestUAPILegacyJunkAndItime(t *testing.T) {
+	dev := randDevice(t)
+	defer dev.Close()
+
+	cfg := strings.Join([]string{
+		"i1=<b 0102><r 8>",
+		"j1=<b aabb><c>",
+		"j2=<r 16>",
+		"j3=<t>",
+		"itime=42",
+		"",
+	}, "\n")
+
+	if err := dev.IpcSet(cfg); err != nil {
+		t.Fatalf("IpcSet rejected legacy 1.5 keys: %v", err)
+	}
+
+	for i, want := range []bool{true, true, true} {
+		if dev.jpackets[i] == nil {
+			t.Errorf("jpackets[%d] = nil, want set (%v)", i, want)
+		}
+	}
+	if dev.ipackets[0] == nil {
+		t.Error("ipackets[0] = nil, want set")
+	}
+
+	dev.imitation.mu.Lock()
+	gotInterval := dev.imitation.interval
+	dev.imitation.mu.Unlock()
+	if gotInterval != 42*time.Second {
+		t.Errorf("imitation.interval = %v, want 42s", gotInterval)
+	}
+
+	got, err := dev.IpcGet()
+	if err != nil {
+		t.Fatalf("IpcGet: %v", err)
+	}
+	for _, want := range []string{"j1=<b aabb><c>", "j2=<r 16>", "j3=<t>", "itime=42"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("IpcGet output missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestUAPIItimeRejectsInvalid checks itime validation.
+func TestUAPIItimeRejectsInvalid(t *testing.T) {
+	dev := randDevice(t)
+	defer dev.Close()
+
+	if err := dev.IpcSet("itime=-1\n"); err == nil {
+		t.Error("IpcSet accepted negative itime, want error")
+	}
+	if err := dev.IpcSet("itime=notanumber\n"); err == nil {
+		t.Error("IpcSet accepted non-numeric itime, want error")
+	}
+}
+
+// TestDueSpecialJunkZeroInterval verifies the AmneziaWG 2.0 behaviour: with a
+// zero imitation interval the special junk is due on every initiation, so the
+// controlled junk is never selected.
+func TestDueSpecialJunkZeroInterval(t *testing.T) {
+	dev := randDevice(t)
+	defer dev.Close()
+
+	for i := 0; i < 5; i++ {
+		if !dev.dueSpecialJunk() {
+			t.Fatalf("dueSpecialJunk() = false on call %d with zero interval, want always true", i)
+		}
+	}
+}
+
+// TestDueSpecialJunkThrottled verifies the AmneziaWG 1.5 behaviour: with a
+// non-zero imitation interval the special junk is due on the first initiation
+// and then gated until the interval elapses.
+func TestDueSpecialJunkThrottled(t *testing.T) {
+	dev := randDevice(t)
+	defer dev.Close()
+
+	dev.imitation.mu.Lock()
+	dev.imitation.interval = time.Hour
+	dev.imitation.mu.Unlock()
+
+	if !dev.dueSpecialJunk() {
+		t.Fatal("dueSpecialJunk() = false on first call, want true")
+	}
+	if dev.dueSpecialJunk() {
+		t.Fatal("dueSpecialJunk() = true within interval, want false (controlled junk turn)")
+	}
+
+	// Force the schedule into the past and confirm the special junk is due again.
+	dev.imitation.mu.Lock()
+	dev.imitation.nextSend = time.Now().Add(-time.Minute)
+	dev.imitation.mu.Unlock()
+	if !dev.dueSpecialJunk() {
+		t.Fatal("dueSpecialJunk() = false after interval elapsed, want true")
+	}
+}
+
+// TestCounterObfChain verifies the restored <c> tag parses and emits an 8-byte
+// monotonic counter.
+func TestCounterObfChain(t *testing.T) {
+	chain, err := newObfChain("<c>")
+	if err != nil {
+		t.Fatalf("newObfChain(<c>): %v", err)
+	}
+	if got := chain.ObfuscatedLen(0); got != 8 {
+		t.Fatalf("ObfuscatedLen(0) = %d, want 8", got)
+	}
+
+	buf1 := make([]byte, chain.ObfuscatedLen(0))
+	chain.Obfuscate(buf1, nil)
+	buf2 := make([]byte, chain.ObfuscatedLen(0))
+	chain.Obfuscate(buf2, nil)
+
+	if string(buf1) == string(buf2) {
+		t.Errorf("counter produced identical consecutive values: %x", buf1)
+	}
+}

--- a/device/device.go
+++ b/device/device.go
@@ -111,6 +111,50 @@ type Device struct {
 	}
 
 	ipackets [5]*obfChain
+
+	// jpackets are AmneziaWG 1.5 "controlled junk" packets (j1..j3). Unlike
+	// ipackets (special junk), they are sent on handshake initiations where the
+	// special junk is not due yet (see imitation below and SendHandshakeInitiation).
+	jpackets [3]*obfChain
+
+	// imitation throttles the special junk packets (ipackets / i1..i5) to the
+	// AmneziaWG 1.5 "imitation interval" (itime). When interval is zero, the
+	// special junk is sent on every handshake initiation, which matches the
+	// AmneziaWG 2.0 behaviour; jpackets are then never sent.
+	imitation struct {
+		mu        sync.Mutex
+		interval  time.Duration
+		nextSend  time.Time
+		firstDone bool
+	}
+}
+
+// dueSpecialJunk reports whether the special junk packets (ipackets) are due to
+// be sent on this handshake initiation, advancing the imitation schedule when
+// they are. It mirrors AmneziaWG 1.5 SpecialHandshakeHandler.GenerateSpecialJunk:
+// the first initiation always sends them, and afterwards they are gated by the
+// itime interval. With a zero interval every initiation is due, so jpackets are
+// never sent — i.e. the AmneziaWG 2.0 behaviour falls out of the same code path.
+func (device *Device) dueSpecialJunk() bool {
+	device.imitation.mu.Lock()
+	defer device.imitation.mu.Unlock()
+
+	// A zero interval means no throttle: the special junk is always due, so the
+	// controlled junk is never sent. This is the AmneziaWG 2.0 behaviour.
+	if device.imitation.interval == 0 {
+		return true
+	}
+
+	if !device.imitation.firstDone {
+		device.imitation.firstDone = true
+		device.imitation.nextSend = time.Now().Add(device.imitation.interval)
+		return true
+	}
+	if !time.Now().After(device.imitation.nextSend) {
+		return false
+	}
+	device.imitation.nextSend = time.Now().Add(device.imitation.interval)
+	return true
 }
 
 // deviceState represents the state of a Device.

--- a/device/obf.go
+++ b/device/obf.go
@@ -10,6 +10,7 @@ type obfBuilder func(val string) (obf, error)
 
 var obfBuilders = map[string]obfBuilder{
 	"b":  newBytesObf,
+	"c":  newCounterObf,
 	"t":  newTimestampObf,
 	"r":  newRandObf,
 	"rc": newRandCharObf,

--- a/device/obf_counter.go
+++ b/device/obf_counter.go
@@ -1,0 +1,38 @@
+package device
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+)
+
+// packetCounter is a process-wide monotonic counter mixed into junk packets by
+// the <c> tag. AmneziaWG 1.5 used a single shared counter (device/awg's
+// PacketCounter); the exact value is never validated on receive (junk is
+// discarded), it only needs to vary between packets.
+var packetCounter atomic.Uint64
+
+// newCounterObf builds the AmneziaWG 1.5 <c> tag: an 8-byte big-endian packet
+// counter. It takes no parameter. Restored on top of the AWG 2.0 obf system for
+// backward compatibility with 1.5 i1..i5 / j1..j3 specifications.
+func newCounterObf(val string) (obf, error) {
+	return &counterObf{}, nil
+}
+
+type counterObf struct{}
+
+func (o *counterObf) Obfuscate(dst, src []byte) {
+	binary.BigEndian.PutUint64(dst, packetCounter.Add(1))
+}
+
+func (o *counterObf) Deobfuscate(dst, src []byte) bool {
+	// The counter carries no information that needs validating on receive.
+	return true
+}
+
+func (o *counterObf) ObfuscatedLen(n int) int {
+	return 8
+}
+
+func (o *counterObf) DeobfuscatedLen(n int) int {
+	return 0
+}

--- a/device/send.go
+++ b/device/send.go
@@ -128,10 +128,28 @@ func (peer *Peer) SendHandshakeInitiation(isRetry bool) error {
 
 	var sendBuffer [][]byte
 
+	// AmneziaWG special/controlled junk. The special junk (i1..i5) is gated by
+	// the imitation interval (itime); on initiations where it is not due, the
+	// controlled junk (j1..j3) is sent instead. The schedule is only consulted
+	// when special junk is actually configured, mirroring AmneziaWG 1.5. With a
+	// zero itime the special junk is always due and the controlled junk is never
+	// sent, which reproduces the AmneziaWG 2.0 behaviour.
+	hasSpecial := false
 	for _, ipacket := range peer.device.ipackets {
 		if ipacket != nil {
-			buf := make([]byte, ipacket.ObfuscatedLen(0))
-			ipacket.Obfuscate(buf, nil)
+			hasSpecial = true
+			break
+		}
+	}
+
+	junkChains := peer.device.jpackets[:]
+	if hasSpecial && peer.device.dueSpecialJunk() {
+		junkChains = peer.device.ipackets[:]
+	}
+	for _, chain := range junkChains {
+		if chain != nil {
+			buf := make([]byte, chain.ObfuscatedLen(0))
+			chain.Obfuscate(buf, nil)
 			sendBuffer = append(sendBuffer, buf)
 		}
 	}

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -147,6 +147,18 @@ func (device *Device) IpcGetOperation(w io.Writer) error {
 			}
 		}
 
+		for i, jpacket := range device.jpackets {
+			if jpacket != nil {
+				sendf("j%d=%s", i+1, jpacket.Spec)
+			}
+		}
+
+		device.imitation.mu.Lock()
+		if device.imitation.interval != 0 {
+			sendf("itime=%d", device.imitation.interval/time.Second)
+		}
+		device.imitation.mu.Unlock()
+
 		for _, peer := range device.peers.keyMap {
 			// Serialize peer state.
 			peer.handshake.mutex.RLock()
@@ -446,6 +458,40 @@ func (device *Device) handleDeviceLine(key, value string) error {
 			return ipcErrorf(ipc.IpcErrorInvalid, "failed to parse I5: %w", err)
 		}
 		device.ipackets[4] = chain
+
+	case "j1":
+		chain, err := newObfChain(value)
+		if err != nil {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to parse J1: %w", err)
+		}
+		device.jpackets[0] = chain
+
+	case "j2":
+		chain, err := newObfChain(value)
+		if err != nil {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to parse J2: %w", err)
+		}
+		device.jpackets[1] = chain
+
+	case "j3":
+		chain, err := newObfChain(value)
+		if err != nil {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to parse J3: %w", err)
+		}
+		device.jpackets[2] = chain
+
+	case "itime":
+		seconds, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to parse itime: %w", err)
+		}
+		if seconds < 0 {
+			return ipcErrorf(ipc.IpcErrorInvalid, "itime must be non-negative")
+		}
+		device.log.Verbosef("UAPI: Updating imitation interval")
+		device.imitation.mu.Lock()
+		device.imitation.interval = time.Duration(seconds) * time.Second
+		device.imitation.mu.Unlock()
 
 	default:
 		return ipcErrorf(ipc.IpcErrorInvalid, "invalid UAPI device key: %v", key)


### PR DESCRIPTION
The 2.0 refactor (#103) dropped the legacy 1.5 obfuscation parameters entirely: the controlled-junk packets (j1..j3), the imitation interval (itime), and the <c> counter tag. This restores them on top of the current 2.0 obf engine so a single build accepts both the 1.5 and 2.0 UAPI key sets; the version is selected by which keys are sent, with no version flag in the library.

- device.go: add jpackets [3]*obfChain (controlled junk) and an imitation schedule; dueSpecialJunk() gates the special junk (i1..i5) by itime. A zero interval means "always due", so the controlled junk is never sent and the behaviour reduces exactly to AWG 2.0.
- uapi.go: parse j1..j3 and itime in handleDeviceLine; emit them in IpcGetOperation.
- send.go: in SendHandshakeInitiation, send the special junk when it is due, otherwise the controlled junk (mirrors AWG 1.5).
- obf_counter.go: re-add the <c> tag (8-byte big-endian packet counter).
- awg_legacy_test.go: cover UAPI round-trip, the itime schedule, and the <c> tag.