### PR TITLE
conn: fix sticky source address on multi-IP hosts

### DIFF
--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -177,6 +177,7 @@ again:
 		s.ipv4TxOffload, s.ipv4RxOffload = supportsUDPOffload(v4conn)
 		if runtime.GOOS == "linux" || runtime.GOOS == "android" {
 			v4pc = ipv4.NewPacketConn(v4conn)
+			_ = v4pc.SetControlMessage(ipv4.FlagDst|ipv4.FlagInterface, true)
 			s.ipv4PC = v4pc
 		}
 		fns = append(fns, s.makeReceiveIPv4(v4pc, v4conn, s.ipv4RxOffload))
@@ -186,6 +187,7 @@ again:
 		s.ipv6TxOffload, s.ipv6RxOffload = supportsUDPOffload(v6conn)
 		if runtime.GOOS == "linux" || runtime.GOOS == "android" {
 			v6pc = ipv6.NewPacketConn(v6conn)
+			_ = v6pc.SetControlMessage(ipv6.FlagDst|ipv6.FlagInterface, true)
 			s.ipv6PC = v6pc
 		}
 		fns = append(fns, s.makeReceiveIPv6(v6pc, v6conn, s.ipv6RxOffload))

--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -368,13 +368,13 @@ func (s *StdNetBind) Send(bufs [][]byte, endpoint Endpoint) error {
 	ua := s.udpAddrPool.Get().(*net.UDPAddr)
 	defer s.udpAddrPool.Put(ua)
 	if is6 {
+		ua.IP = ua.IP[:16]
 		as16 := endpoint.DstIP().As16()
 		copy(ua.IP, as16[:])
-		ua.IP = ua.IP[:16]
 	} else {
+		ua.IP = ua.IP[:4]
 		as4 := endpoint.DstIP().As4()
 		copy(ua.IP, as4[:])
-		ua.IP = ua.IP[:4]
 	}
 	ua.Port = int(endpoint.(*StdNetEndpoint).Port())
 	var (

--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -528,6 +528,11 @@ func splitCoalescedMessages(msgs []ipv6.Message, firstMsgAt int, getGSO getGSOFu
 			copied := copy(msgs[n].Buffers[0], msg.Buffers[0][start:end])
 			msgs[n].N = copied
 			msgs[n].Addr = msg.Addr
+			if n != i {
+				oobCopied := copy(msgs[n].OOB[:cap(msgs[n].OOB)], msg.OOB[:msg.NN])
+				msgs[n].OOB = msgs[n].OOB[:oobCopied]
+				msgs[n].NN = oobCopied
+			}
 			start = end
 			end += gsoSize
 			if end > msg.N {


### PR DESCRIPTION
## Summary

Three independent bugs in `conn/bind_std.go` break the sticky source address feature on multi-IP hosts. On a server with multiple global IPv6 addresses (e.g. a static `::100` and a DHCPv6-assigned `::943`), the server responds to handshake initiations with the kernel's route-preferred source rather than the destination the peer connected to, so the peer rejects the response and the session never establishes.

## Patches

1. **`conn: enable IP_PKTINFO ancillary data on PacketConn`** — call `SetControlMessage(FlagDst|FlagInterface, true)` after `NewPacketConn`. Without it, `ipv6.PacketConn.ReadBatch`/`RecvMsgs` discards the PKTINFO cmsg even though `IPV6_RECVPKTINFO=1` is set at the socket level — `Message.NN` always returns 0, `ep.src` never populates, sticky source becomes a silent no-op.
2. **`conn: reset udpAddrPool slice length before copy`** — `Send()` truncates `ua.IP` *after* `copy(...)`, so after a v4 send the pooled `*net.UDPAddr` has `len(IP)==4`, and the next v6 reuse only writes the upper 4 bytes of the IPv6 destination, leaving 12 stale bytes from the previous send. Resize the slice before the copy.
3. **`conn: propagate ancillary data to coalesced split frames`** — `splitCoalescedMessages` copies `Buffers[0]`, `N`, and `Addr` to each child frame but never propagates `OOB`/`NN`. With UDP_GRO active (Linux 5.12+), every frame past the first loses its PKTINFO and sticky source breaks even after fix #1 is applied.

Each commit fixes one independent issue and is self-contained; they can be applied or reverted individually.

## Reproduction

Network namespaces with a server holding `::100` and `::943` on the same `/64`, where `ip route get <client>` returns `src ::943`:

```
sudo ip netns add srvns && sudo ip netns add cltns
sudo ip link add veth-srv type veth peer name veth-srvNS
sudo ip link add veth-clt type veth peer name veth-cltNS
sudo ip link set veth-srvNS netns srvns
sudo ip link set veth-cltNS netns cltns
sudo ip link add br-test type bridge
sudo ip link set veth-srv master br-test
sudo ip link set veth-clt master br-test
sudo ip link set veth-srv up; sudo ip link set veth-clt up; sudo ip link set br-test up
sudo ip netns exec srvns ip link set veth-srvNS up
sudo ip netns exec srvns ip -6 addr add fd00:1::100/64 dev veth-srvNS
sudo ip netns exec srvns ip -6 addr add fd00:1::943/64 dev veth-srvNS
sudo ip netns exec cltns ip link set veth-cltNS up
sudo ip netns exec cltns ip -6 addr add fd00:1::1/64 dev veth-cltNS
sleep 3  # DAD
```

Then run an amneziawg-go server in `srvns` listening on port 53400, and a client in `cltns` with `Endpoint = [fd00:1::100]:53400`. Without the patches, `tcpdump -i br-test` shows the handshake response coming from `fd00:1::943`. With the patches, the response comes from `fd00:1::100` and the client does not roam endpoints.

## Testing

End-to-end tested in netns on Linux 6.x (both arm64 and x86_64). Verified against a real-world production setup where this bug was causing handshake failures for an IPv6 client behind a sticky-source-sensitive peer; with the patches applied, the workaround route (`ip -6 route ... src ::100`) was removed and the tunnel handshakes cleanly.

This same patch series is being submitted to wireguard-go upstream (the bugs are identical there since amneziawg-go inherits `conn/bind_std.go`).

## Test plan

- [x] All three commits build with `go 1.23+`
- [x] Reproduction in netns shows the handshake response source IP changes from `::943` to `::100` after the patches
- [x] Existing handshake/keepalive flows continue to work
- [x] No new dependencies introduced
