### PR TITLE
feat: add Salamander ObfsPSK support

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -110,6 +110,8 @@ type Device struct {
 		transport int
 	}
 
+	obfsPSK NoisePresharedKey
+
 	ipackets [5]*obfChain
 }
 

--- a/device/peer.go
+++ b/device/peer.go
@@ -133,7 +133,19 @@ func (peer *Peer) SendBuffers(buffers [][]byte) error {
 	}
 	peer.endpoint.Unlock()
 
-	err := peer.device.net.bind.Send(buffers, endpoint)
+	sendBuffers := buffers
+	if peer.device.salamanderEnabled() {
+		sendBuffers = make([][]byte, 0, len(buffers))
+		for _, buffer := range buffers {
+			obfuscated, err := peer.device.salamanderObfuscate(buffer)
+			if err != nil {
+				return err
+			}
+			sendBuffers = append(sendBuffers, obfuscated)
+		}
+	}
+
+	err := peer.device.net.bind.Send(sendBuffers, endpoint)
 	if err == nil {
 		var totalLen uint64
 		for _, b := range buffers {

--- a/device/receive.go
+++ b/device/receive.go
@@ -131,12 +131,16 @@ func (device *Device) RoutineReceiveIncoming(
 
 		// handle each packet in the batch
 		for i, size := range sizes[:count] {
-			if size < MinMessageSize {
+			packet := bufsArrs[i][:size]
+			var ok bool
+			packet, ok = device.salamanderDeobfuscate(packet)
+			if !ok {
 				continue
 			}
 
-			// check size of packet
-			packet := bufsArrs[i][:size]
+			if len(packet) < MinMessageSize {
+				continue
+			}
 
 			// get message padding and type based on information from S1-S4 and H1-H4
 			msgType, padding := device.DeterminePacketTypeAndPadding(packet, MessageUnknownType)

--- a/device/salamander.go
+++ b/device/salamander.go
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2025 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math/big"
+
+	"golang.org/x/crypto/blake2s"
+)
+
+const (
+	salamanderSaltLen    = 8
+	salamanderKeyLen     = 32
+	salamanderPadHdrLen  = 2
+	salamanderOverhead   = salamanderSaltLen + salamanderPadHdrLen
+	salamanderPadMin     = 800
+	salamanderPadMax     = 1500
+	salamanderPadExtra   = 50
+	salamanderMaxPadding = salamanderPadMax + salamanderPadExtra
+)
+
+func (device *Device) salamanderEnabled() bool {
+	var zero NoisePresharedKey
+	return subtle.ConstantTimeCompare(device.obfsPSK[:], zero[:]) != 1
+}
+
+func (device *Device) salamanderObfuscate(packet []byte) ([]byte, error) {
+	if !device.salamanderEnabled() {
+		return packet, nil
+	}
+
+	payloadWithHeader := len(packet) + salamanderOverhead
+	target, err := randomIntInclusive(salamanderPadMin, salamanderPadMax)
+	if err != nil {
+		return nil, err
+	}
+
+	padLen := 0
+	if payloadWithHeader < target {
+		padLen = target - payloadWithHeader
+	} else {
+		padLen, err = randomIntInclusive(0, salamanderPadExtra)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	out := make([]byte, salamanderOverhead+len(packet)+padLen)
+	salt := out[:salamanderSaltLen]
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, err
+	}
+
+	payload := out[salamanderSaltLen:]
+	binary.LittleEndian.PutUint16(payload[:salamanderPadHdrLen], uint16(padLen))
+	copy(payload[salamanderPadHdrLen:], packet)
+	if padLen > 0 {
+		if _, err := io.ReadFull(rand.Reader, payload[salamanderPadHdrLen+len(packet):]); err != nil {
+			return nil, err
+		}
+	}
+
+	key := device.salamanderDeriveKey(salt)
+	xorWithRepeatingKey(payload, key[:])
+	return out, nil
+}
+
+func (device *Device) salamanderDeobfuscate(packet []byte) ([]byte, bool) {
+	if !device.salamanderEnabled() {
+		return packet, true
+	}
+	if len(packet) <= salamanderOverhead {
+		return nil, false
+	}
+
+	salt := packet[:salamanderSaltLen]
+	payload := packet[salamanderSaltLen:]
+	key := device.salamanderDeriveKey(salt)
+	xorWithRepeatingKey(payload, key[:])
+
+	padLen := int(binary.LittleEndian.Uint16(payload[:salamanderPadHdrLen]))
+	payload = payload[salamanderPadHdrLen:]
+	if padLen > len(payload) {
+		return nil, false
+	}
+	payload = payload[:len(payload)-padLen]
+
+	copy(packet, payload)
+	return packet[:len(payload)], true
+}
+
+func (device *Device) salamanderDeriveKey(salt []byte) [salamanderKeyLen]byte {
+	hash, _ := blake2s.New256(nil)
+	hash.Write(device.obfsPSK[:])
+	hash.Write(salt)
+
+	var key [salamanderKeyLen]byte
+	copy(key[:], hash.Sum(nil))
+	return key
+}
+
+func randomIntInclusive(min, max int) (int, error) {
+	if min > max {
+		return 0, errors.New("invalid random range")
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max-min+1)))
+	if err != nil {
+		return 0, err
+	}
+	return int(n.Int64()) + min, nil
+}
+
+func xorWithRepeatingKey(data, key []byte) {
+	for i := range data {
+		data[i] ^= key[i%len(key)]
+	}
+}

--- a/device/salamander_test.go
+++ b/device/salamander_test.go
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2025 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSalamanderRoundTrip(t *testing.T) {
+	device := &Device{}
+	for i := range device.obfsPSK {
+		device.obfsPSK[i] = byte(i + 1)
+	}
+
+	packet := []byte("wireguard packet")
+	obfuscated, err := device.salamanderObfuscate(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(packet, obfuscated) {
+		t.Fatal("obfuscated packet unexpectedly matches plaintext")
+	}
+	if len(obfuscated) < salamanderPadMin {
+		t.Fatalf("obfuscated packet too short: %d", len(obfuscated))
+	}
+
+	deobfuscated, ok := device.salamanderDeobfuscate(obfuscated)
+	if !ok {
+		t.Fatal("failed to deobfuscate")
+	}
+	if !bytes.Equal(packet, deobfuscated) {
+		t.Fatalf("round trip mismatch: got %x want %x", deobfuscated, packet)
+	}
+}
+
+func TestSalamanderDisabledReturnsInput(t *testing.T) {
+	device := &Device{}
+	packet := []byte("wireguard packet")
+
+	obfuscated, err := device.salamanderObfuscate(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(packet, obfuscated) {
+		t.Fatal("disabled obfuscation changed packet")
+	}
+
+	deobfuscated, ok := device.salamanderDeobfuscate(packet)
+	if !ok {
+		t.Fatal("disabled deobfuscation failed")
+	}
+	if !bytes.Equal(packet, deobfuscated) {
+		t.Fatal("disabled deobfuscation changed packet")
+	}
+}

--- a/device/send.go
+++ b/device/send.go
@@ -250,6 +250,14 @@ func (device *Device) SendHandshakeCookie(initiatingElem *QueueHandshakeElement)
 		packet = buf
 	}
 
+	if device.salamanderEnabled() {
+		obfuscated, err := device.salamanderObfuscate(packet)
+		if err != nil {
+			return err
+		}
+		packet = obfuscated
+	}
+
 	// TODO: allocation could be avoided
 	device.net.bind.Send([][]byte{packet}, initiatingElem.endpoint)
 	return nil

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -89,6 +89,10 @@ func (device *Device) IpcGetOperation(w io.Writer) error {
 			keyf("private_key", (*[32]byte)(&device.staticIdentity.privateKey))
 		}
 
+		if device.salamanderEnabled() {
+			keyf("obfs_psk", (*[32]byte)(&device.obfsPSK))
+		}
+
 		if device.net.port != 0 {
 			sendf("listen_port=%d", device.net.port)
 		}
@@ -267,6 +271,15 @@ func (device *Device) handleDeviceLine(key, value string) error {
 		}
 		device.log.Verbosef("UAPI: Updating private key")
 		device.SetPrivateKey(sk)
+
+	case "obfs_psk":
+		var obfsPSK NoisePresharedKey
+		err := obfsPSK.FromHex(value)
+		if err != nil {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to set obfs_psk: %w", err)
+		}
+		device.log.Verbosef("UAPI: Updating obfs psk")
+		device.obfsPSK = obfsPSK
 
 	case "listen_port":
 		port, err := strconv.ParseUint(value, 10, 16)


### PR DESCRIPTION
## Summary
- add stateless Salamander packet obfuscation keyed by device-level obfs_psk
- expose obfs_psk through UAPI get/set
- obfuscate data, handshake cookie, and incoming packet paths when ObfsPSK is configured

## Validation
- go test ./device -run 'TestSalamander' -count=1
- Lima AWG2 E2E with kernel ulta-plus/vpnn-master + tools ObfsPSK: tunnel ping both directions, external ping through tunnel, parallel site fetches, 10MB throughput download, fallback video download

Note: YouTube egress is currently refused from both host and Lima VM before the tunnel, so the YouTube-specific download was recorded as environment-blocked while the tunnel throughput/video fallback passed.