### PR TITLE
conn: don't reset the listen port to 0 when IPv6 is unavailable

### DIFF
--- a/conn/bind_std.go
+++ b/conn/bind_std.go
@@ -155,6 +155,7 @@ again:
 	var v4conn, v6conn *net.UDPConn
 	var v4pc *ipv4.PacketConn
 	var v6pc *ipv6.PacketConn
+	var v6port int
 
 	v4conn, port, err = listenNet("udp4", port)
 	if err != nil && !errors.Is(err, syscall.EAFNOSUPPORT) {
@@ -162,7 +163,7 @@ again:
 	}
 
 	// Listen on the same port as we're using for ipv4.
-	v6conn, port, err = listenNet("udp6", port)
+	v6conn, v6port, err = listenNet("udp6", port)
 	if uport == 0 && errors.Is(err, syscall.EADDRINUSE) && tries < 100 {
 		v4conn.Close()
 		tries++
@@ -171,6 +172,9 @@ again:
 	if err != nil && !errors.Is(err, syscall.EAFNOSUPPORT) {
 		v4conn.Close()
 		return nil, 0, err
+	}
+	if v6conn != nil {
+		port = v6port
 	}
 	var fns []ReceiveFunc
 	if v4conn != nil {


### PR DESCRIPTION
## Problem

`StdNetBind.Open` binds the udp4 and udp6 sockets into the same `port` variable:

```go
v4conn, port, err = listenNet("udp4", port)
...
v6conn, port, err = listenNet("udp6", port)
```

On a host with IPv6 disabled in the kernel (`ipv6.disable=1` on the kernel command line, or the `ipv6` module blacklisted), the udp6 `ListenPacket` returns `EAFNOSUPPORT`. That error is intentionally tolerated, but the assignment has already overwritten the port udp4 successfully bound with `0`. `Open` then returns `actualPort == 0` even though the v4 socket is bound and serving traffic.

Because the UAPI `get` handler only emits `listen_port` when it is non-zero, the line disappears entirely, so anything that reads the port back (wgctrl, `awg show`, a control plane reconciling expected vs. live config) sees `0`.

## Fix

Give the udp6 listener its own `port` variable and adopt it only when v6 actually bound. A udp6 `EAFNOSUPPORT` no longer clobbers the live udp4 port.

## Note

This code is inherited verbatim from upstream wireguard-go (`conn/bind_std.go`), so the same bug exists there.
