### PR TITLE
build: publish multi-arch Docker image (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/build-if-tag.yml
+++ b/.github/workflows/build-if-tag.yml
@@ -31,6 +31,9 @@ jobs:
           images: amneziavpn/${{ env.APP }}
           tags: type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -38,4 +41,5 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM golang:1.24.4 as awg
+FROM golang:1.24.4 AS awg
 COPY . /awg
 WORKDIR /awg
 RUN go mod download && \
     go mod verify && \
     go build -ldflags '-linkmode external -extldflags "-fno-PIC -static"' -v -o /usr/bin
 
-FROM alpine:3.19
+FROM alpine:3.19 AS awg-tools
 ARG AWGTOOLS_RELEASE="1.0.20250901"
+RUN apk --no-cache add git make gcc musl-dev linux-headers bash && \
+    git clone --depth 1 --branch "v${AWGTOOLS_RELEASE}" https://github.com/amnezia-vpn/amneziawg-tools.git /awg-tools && \
+    make -C /awg-tools/src && \
+    make -C /awg-tools/src install WITH_BASHCOMPLETION=no WITH_SYSTEMDUNITS=no WITH_WGQUICK=yes
 
+FROM alpine:3.19
 RUN apk --no-cache add iproute2 iptables bash && \
-    cd /usr/bin/ && \
-    wget https://github.com/amnezia-vpn/amneziawg-tools/releases/download/v${AWGTOOLS_RELEASE}/alpine-3.19-amneziawg-tools.zip && \
-    unzip -j alpine-3.19-amneziawg-tools.zip && \
-    chmod +x /usr/bin/awg /usr/bin/awg-quick && \
     ln -s /usr/bin/awg /usr/bin/wg && \
     ln -s /usr/bin/awg-quick /usr/bin/wg-quick
+COPY --from=awg-tools /usr/bin/awg /usr/bin/awg-quick /usr/bin/
 COPY --from=awg /usr/bin/amneziawg-go /usr/bin/amneziawg-go


### PR DESCRIPTION
## What

Publish the Docker image for both `linux/amd64` and `linux/arm64`.

## Why

The image on Docker Hub is currently amd64-only, so installing AmneziaWG (2.0) from the AmneziaVPN app fails on arm64 servers (Raspberry Pi, AWS Graviton, Oracle Ampere, Hetzner CAX) — the app's `docker build --pull` pulls an amd64-only base. See #65 (closed) and amnezia-vpn/amnezia-client#869.

The previous attempt (#65) only added `platforms:` to the workflow, which is not enough: the Dockerfile downloads a prebuilt **amd64-only** `alpine-3.19-amneziawg-tools.zip` from GitHub releases, so an arm64 image would still contain amd64 `awg`/`awg-quick` binaries.

## How

- **Dockerfile**: build `amneziawg-tools` from source (same pinned release tag `v1.0.20250901`) in a dedicated build stage instead of downloading the zip. The final stage is unchanged in layout: `awg`, `awg-quick`, `wg`/`wg-quick` symlinks, `amneziawg-go`. This makes the image buildable for any platform and removes the runtime dependency on release artifacts.
- **Workflow**: add `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` to the publish step.
- Fixes the two `FromAsCasing` build warnings as a drive-by.

## Alternative

If you would rather keep the release-zip download approach, amnezia-vpn/amneziawg-tools#57 adds arm64 zips to the tools release artifacts. Once that is merged and a new tools release is tagged, I'm happy to rework this PR to select the zip by `TARGETARCH` instead of building from source — building from source is proposed here only because it needs no coordination between the two repos and works for already-published tools tags.

## Testing

Built and ran both platforms locally with `docker buildx`:

- `linux/arm64` (native on Apple Silicon / verified binaries on Raspberry Pi 5): `amneziawg-go --version` → `Userspace AmneziaWG daemon for linux-arm64`, `awg --version` → `amneziawg-tools v1.0.20210914`, symlinks present.
- `linux/amd64` (no regression): `amneziawg-go --version` → `Userspace AmneziaWG daemon for linux-amd64`, `awg --version` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
