### PR TITLE
feat: make PreallocatedBuffersPerPool configurable at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ When an interface is running, you may use [`amneziawg-tools `](https://github.co
 
 To run with more logging you may set the environment variable `LOG_LEVEL=debug`.
 
+On memory-constrained hosts (e.g. consumer routers with 256–512 MB of RAM) you may bound the internal buffer pools by setting the environment variable `WG_PREALLOCATED_BUFFERS_PER_POOL=1024`. When the bound is reached the receive path waits for a free buffer instead of allocating a new one, so sustained traffic bursts no longer grow the heap without limit (the kernel drops excess UDP, which peers handle as ordinary congestion). The default (`0` on Linux) keeps the historical unbounded behavior; embedders using the `device` package directly can assign `device.PreallocatedBuffersPerPool` before calling `NewDevice`.
+
 ## Platforms
 
 ### Linux

--- a/device/queueconstants_android.go
+++ b/device/queueconstants_android.go
@@ -10,10 +10,13 @@ import "github.com/amnezia-vpn/amneziawg-go/conn"
 /* Reduce memory consumption for Android */
 
 const (
-	QueueStagedSize            = conn.IdealBatchSize
-	QueueOutboundSize          = 1024
-	QueueInboundSize           = 1024
-	QueueHandshakeSize         = 1024
-	MaxSegmentSize             = (1 << 16) - 1 // largest possible UDP datagram
-	PreallocatedBuffersPerPool = 4096
+	QueueStagedSize    = conn.IdealBatchSize
+	QueueOutboundSize  = 1024
+	QueueInboundSize   = 1024
+	QueueHandshakeSize = 1024
+	MaxSegmentSize     = (1 << 16) - 1 // largest possible UDP datagram
 )
+
+// A var instead of a const (like on ios) so embedders can adjust the bound
+// to their memory budget before calling NewDevice.
+var PreallocatedBuffersPerPool uint32 = 4096

--- a/device/queueconstants_default.go
+++ b/device/queueconstants_default.go
@@ -10,10 +10,16 @@ package device
 import "github.com/amnezia-vpn/amneziawg-go/conn"
 
 const (
-	QueueStagedSize            = conn.IdealBatchSize
-	QueueOutboundSize          = 1024
-	QueueInboundSize           = 1024
-	QueueHandshakeSize         = 1024
-	MaxSegmentSize             = (1 << 16) - 1 // largest possible UDP datagram
-	PreallocatedBuffersPerPool = 0             // Disable and allow for infinite memory growth
+	QueueStagedSize    = conn.IdealBatchSize
+	QueueOutboundSize  = 1024
+	QueueInboundSize   = 1024
+	QueueHandshakeSize = 1024
+	MaxSegmentSize     = (1 << 16) - 1 // largest possible UDP datagram
 )
+
+// PreallocatedBuffersPerPool is a var instead of a const (like on ios), so that
+// memory-constrained hosts — e.g. consumer routers running the standalone daemon —
+// can bound the buffer pools without patching the source. Assign it before calling
+// NewDevice (the daemon reads WG_PREALLOCATED_BUFFERS_PER_POOL from the environment).
+// 0 keeps the default behavior: disable and allow for infinite memory growth.
+var PreallocatedBuffersPerPool uint32 = 0

--- a/device/queueconstants_windows.go
+++ b/device/queueconstants_windows.go
@@ -6,10 +6,14 @@
 package device
 
 const (
-	QueueStagedSize            = 128
-	QueueOutboundSize          = 1024
-	QueueInboundSize           = 1024
-	QueueHandshakeSize         = 1024
-	MaxSegmentSize             = 2048 - 32 // largest possible UDP datagram
-	PreallocatedBuffersPerPool = 0         // Disable and allow for infinite memory growth
+	QueueStagedSize    = 128
+	QueueOutboundSize  = 1024
+	QueueInboundSize   = 1024
+	QueueHandshakeSize = 1024
+	MaxSegmentSize     = 2048 - 32 // largest possible UDP datagram
 )
+
+// A var instead of a const (like on ios) so embedders can adjust the bound
+// to their memory budget before calling NewDevice.
+// 0 keeps the default behavior: disable and allow for infinite memory growth.
+var PreallocatedBuffersPerPool uint32 = 0

--- a/main.go
+++ b/main.go
@@ -27,9 +27,10 @@ const (
 )
 
 const (
-	ENV_WG_TUN_FD             = "WG_TUN_FD"
-	ENV_WG_UAPI_FD            = "WG_UAPI_FD"
-	ENV_WG_PROCESS_FOREGROUND = "WG_PROCESS_FOREGROUND"
+	ENV_WG_TUN_FD                        = "WG_TUN_FD"
+	ENV_WG_UAPI_FD                       = "WG_UAPI_FD"
+	ENV_WG_PROCESS_FOREGROUND            = "WG_PROCESS_FOREGROUND"
+	ENV_WG_PREALLOCATED_BUFFERS_PER_POOL = "WG_PREALLOCATED_BUFFERS_PER_POOL"
 )
 
 func printUsage() {
@@ -150,6 +151,19 @@ func main() {
 	if err != nil {
 		logger.Errorf("Failed to create TUN device: %v", err)
 		os.Exit(ExitSetupFailed)
+	}
+
+	// optionally bound the buffer pools (must happen before the device is
+	// created; the default is the platform profile in device/queueconstants_*.go)
+
+	if poolSizeStr := os.Getenv(ENV_WG_PREALLOCATED_BUFFERS_PER_POOL); poolSizeStr != "" {
+		poolSize, err := strconv.ParseUint(poolSizeStr, 10, 32)
+		if err != nil {
+			logger.Errorf("Invalid %s: %v", ENV_WG_PREALLOCATED_BUFFERS_PER_POOL, err)
+			os.Exit(ExitSetupFailed)
+		}
+		device.PreallocatedBuffersPerPool = uint32(poolSize)
+		logger.Verbosef("Buffer pools bounded at %d buffers each", poolSize)
 	}
 
 	// open UAPI file (or use supplied fd)


### PR DESCRIPTION
On memory-constrained hosts (consumer routers with 256-512 MB of RAM) the Linux default of PreallocatedBuffersPerPool = 0 lets the receive path allocate 64 KiB message buffers without bound whenever sustained inbound traffic outpaces the (software) crypto pipeline. Field case: an ASUS RT-AX82U (512 MB, armv7) running the standalone daemon dies with `fatal error: runtime: out of memory` a few minutes into any sustained stream, allocation stack in
RoutineReceiveIncoming -> GetMessageBuffer -> WaitPool.Get. Rebuilding with the pool bounded at 1024 (the value the ios profile already ships) fixes it: WaitPool.Get blocks the receiver when the pool is full, the kernel drops excess UDP, and peers treat that as ordinary congestion.

Make the bound adjustable without patching the source:

- turn PreallocatedBuffersPerPool into a typed var on the default, android and windows profiles; ios already declares it as a var for exactly this reason. Platform defaults are unchanged.
- the standalone daemon reads WG_PREALLOCATED_BUFFERS_PER_POOL from the environment (same configuration surface as LOG_LEVEL and WG_PROCESS_FOREGROUND) before creating the device; unset keeps the platform default, 0 means unbounded, and a non-numeric value fails startup with a clear error.
- embedders using the device package directly can assign device.PreallocatedBuffersPerPool before calling NewDevice.