### PR TITLE
Потеря первого transport-пакета при настройке S4

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Header protection is the mechanism of protecting low-entropy values of packets' 
 > Use `awg genkey` to generate header protection key
 
 > [!IMPORTANT]
-> Header protection requires `S1-S4` value to be 8 at least
+> Header protection requires `S1-S4` value to be 12 at least
 
 ### Content padding [AWG 3+]
 

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -188,6 +188,14 @@ func genTestPair(
 			level = LogLevelError
 		}
 		p.dev = NewDevice(p.tun.TUN(), binds[i], NewLogger(level, fmt.Sprintf("dev%d: ", i)))
+
+		select {
+		case <-p.tun.ReadStarted():
+		case <-time.After(time.Second):
+			p.dev.Close()
+			tb.Fatalf("TUN reader for device %d did not start", i)
+		}
+
 		if err := p.dev.IpcSet(cfg[i]); err != nil {
 			tb.Errorf("failed to configure device %d: %v", i, err)
 			p.dev.Close()
@@ -224,6 +232,13 @@ func TestTwoDevicePing(t *testing.T) {
 	})
 }
 
+func TestS4ConfiguredWhileTUNReadBlocked(t *testing.T) {
+	goroutineLeakCheck(t)
+
+	pair := genTestPair(t, true, "s4", "25")
+	pair.Send(t, Ping, nil)
+}
+
 // Run test with -race=false to avoid the race for setting the default msgTypes 2 times
 func TestAWGDevicePing(t *testing.T) {
 	goroutineLeakCheck(t)
@@ -246,6 +261,76 @@ func TestAWGDevicePing(t *testing.T) {
 	})
 	t.Run("ping 1.0.0.2", func(t *testing.T) {
 		pair.Send(t, Pong, nil)
+	})
+}
+
+func TestAWG3DevicePing(t *testing.T) {
+	goroutineLeakCheck(t)
+
+	pair := genTestPair(t, true,
+		"jc", "6",
+		"jmin", "10",
+		"jmax", "50",
+		"s1", "87",
+		"s2", "23",
+		"s3", "12",
+		"s4", "15",
+		"h1", "335621506-947879090",
+		"h2", "1362325490-1883963371",
+		"h3", "2101810250-2138881068",
+		"h4", "2142245514-2145625027",
+		"header_protection_key", "d3a61555310d751bb36b70733da9b2325bbf0eba909367bd8138f910a881666f",
+		"content_padding_addition", "100",
+		"rekey_after_time", "120",
+		"rekey_timeout", "5",
+		"reject_after_time", "180",
+		"keepalive_timeout", "10",
+		"max_handshake_attempts", "5",
+	)
+	t.Run("ping 1.0.0.1", func(t *testing.T) {
+		pair.Send(t, Ping, nil)
+	})
+	t.Run("ping 1.0.0.2", func(t *testing.T) {
+		pair.Send(t, Pong, nil)
+	})
+}
+
+func TestHeaderProtectionRequiresAtLeast12BytesOfPadding(t *testing.T) {
+	tunDevice := tuntest.NewChannelTUN()
+	binds := bindtest.NewChannelBinds()
+	dev := NewDevice(tunDevice.TUN(), binds[0], NewLogger(LogLevelSilent, ""))
+	t.Cleanup(dev.Close)
+
+	const headerProtectionKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+	paddingKeys := []string{"s1", "s2", "s3", "s4"}
+	for i, paddingKey := range paddingKeys {
+		t.Run(fmt.Sprintf("S%d=11_is_rejected", i+1), func(t *testing.T) {
+			cfg := []string{
+				"s1", "12",
+				"s2", "12",
+				"s3", "12",
+				"s4", "12",
+				"header_protection_key", headerProtectionKey,
+			}
+			cfg[i*2+1] = "11"
+
+			if err := dev.IpcSet(uapiCfg(cfg...)); err == nil {
+				t.Errorf("%s=11 was accepted with header protection enabled", paddingKey)
+			}
+		})
+	}
+
+	t.Run("S1-S4=12_is_accepted", func(t *testing.T) {
+		err := dev.IpcSet(uapiCfg(
+			"s1", "12",
+			"s2", "12",
+			"s3", "12",
+			"s4", "12",
+			"header_protection_key", headerProtectionKey,
+		))
+		if err != nil {
+			t.Fatalf("S1-S4=12: unexpected error: %v", err)
+		}
 	})
 }
 

--- a/device/send.go
+++ b/device/send.go
@@ -310,14 +310,20 @@ func (device *Device) RoutineReadFromTUN() {
 	}()
 
 	for {
-		padding := device.paddings.transport.Load()
-		offset := MessageTransportHeaderSize + int(padding)
+		readPadding := device.paddings.transport.Load()
+		readOffset := MessageTransportHeaderSize + int(readPadding)
 
 		// read packets
-		count, readErr = device.tun.device.Read(bufs, sizes, offset)
+		count, readErr = device.tun.device.Read(bufs, sizes, readOffset)
+		padding := device.paddings.transport.Load()
+		offset := MessageTransportHeaderSize + int(padding)
 		for i := 0; i < count; i++ {
 			if sizes[i] < 1 {
 				continue
+			}
+
+			if offset != readOffset {
+				copy(bufs[i][offset:offset+sizes[i]], bufs[i][readOffset:readOffset+sizes[i]])
 			}
 
 			elem := elems[i]

--- a/tun/tuntest/tuntest.go
+++ b/tun/tuntest/tuntest.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/netip"
 	"os"
+	"sync"
 
 	"github.com/amnezia-vpn/amneziawg-go/v3/tun"
 )
@@ -86,14 +87,18 @@ type ChannelTUN struct {
 	closed chan struct{}
 	events chan tun.Event
 	tun    chTun
+
+	readStarted     chan struct{}
+	readStartedOnce sync.Once
 }
 
 func NewChannelTUN() *ChannelTUN {
 	c := &ChannelTUN{
-		Inbound:  make(chan []byte),
-		Outbound: make(chan []byte),
-		closed:   make(chan struct{}),
-		events:   make(chan tun.Event, 1),
+		Inbound:     make(chan []byte),
+		Outbound:    make(chan []byte),
+		closed:      make(chan struct{}),
+		events:      make(chan tun.Event, 1),
+		readStarted: make(chan struct{}),
 	}
 	c.tun.c = c
 	c.events <- tun.EventUp
@@ -104,6 +109,10 @@ func (c *ChannelTUN) TUN() tun.Device {
 	return &c.tun
 }
 
+func (c *ChannelTUN) ReadStarted() <-chan struct{} {
+	return c.readStarted
+}
+
 type chTun struct {
 	c *ChannelTUN
 }
@@ -111,6 +120,10 @@ type chTun struct {
 func (t *chTun) File() *os.File { return nil }
 
 func (t *chTun) Read(packets [][]byte, sizes []int, offset int) (int, error) {
+	t.c.readStartedOnce.Do(func() {
+		close(t.c.readStarted)
+	})
+
 	select {
 	case <-t.c.closed:
 		return 0, os.ErrClosed


### PR DESCRIPTION
Исправлена обработка случая, когда S4 меняется во время блокирующего чтения из TUN, из-за чего первый transport-пакет отправлялся со старым padding. Добавлены регрессионные тесты и проверка минимального значения S1–S4 = 12 для Header Protection