### PR TITLE
device: AWG 3.0 - don't count S4-padded keepalives as data (idle re-handshake storm)

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -628,7 +628,15 @@ func (peer *Peer) RoutineSequentialSender(maxBatchSize int) {
 		dataSent := false
 		elemsContainer.Lock()
 		for _, elem := range elemsContainer.elems {
-			if len(elem.packet) != MessageKeepaliveSize {
+			// A keepalive carries no user data, so it must NOT arm the
+			// data-sent timers. Since AWG 2.0 the sealed packet is prefixed
+			// with elem.padding bytes of S4 crypto padding (RoutineEncryption
+			// seals from elem.buffer[:elem.padding+MessageTransportHeaderSize]),
+			// so a keepalive measures elem.padding+MessageKeepaliveSize, not
+			// MessageKeepaliveSize. Comparing against the bare constant made
+			// every keepalive look like data whenever S4 > 0, which armed
+			// newHandshake (~15 s) on an idle tunnel and re-handshaked forever.
+			if len(elem.packet) != int(elem.padding)+MessageKeepaliveSize {
 				dataSent = true
 			}
 


### PR DESCRIPTION
AWG 3.0 moved the S4 transport padding into RoutineEncryption, which now seals from elem.buffer[:elem.padding+MessageTransportHeaderSize]. The sealed keepalive therefore measures elem.padding+MessageKeepaliveSize, but RoutineSequentialSender still compared it against the bare MessageKeepaliveSize constant.

With S4 > 0 every keepalive was consequently classified as data, so timersDataSent() armed newHandshake (~15 s + jitter) on a completely idle tunnel. Nothing inbound ever answers a keepalive, so the timer expired into markEndpointSrcForClearing() + SendHandshakeInitiation() and the peer re-handshaked forever.

Measured on an idle tunnel with PersistentKeepalive=5s over 75 s (handshake count read from last_handshake_time_*):

              S4=0   S4=30
  v0.2.19       1       1
  v3.0.1        1       5     <- storm, ~1 handshake / 15 s
  v3.0.1+fix    1       1

Also reproduced with a v3 client against an unmodified v0.2.19 peer, so it breaks existing deployments on upgrade, not just v3-to-v3 ones.

Compare against elem.padding+MessageKeepaliveSize instead. Real data is unaffected: a data packet is padding+16+content+16 with content > 0, so it still exceeds the keepalive size and still arms the data timers.