### PR TITLE
Use stdlib atomic.Bool instead of go.uber.org/atomic

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -18,10 +18,9 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/amnezia-vpn/amneziawg-go/v3/conn"
 	"github.com/amnezia-vpn/amneziawg-go/v3/conn/bindtest"
@@ -255,7 +254,8 @@ func TestAWGHandshakeDevicePing(t *testing.T) {
 
 	signalContext, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
-	isRunning := atomic.NewBool(true)
+	var isRunning atomic.Bool
+	isRunning.Store(true)
 	go func() {
 		<-signalContext.Done()
 		fmt.Println("Waiting to finish")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/goccy/go-yaml v1.17.1
-	go.uber.org/atomic v1.11.0
 	golang.getoutline.org/sdk v0.0.23
 	golang.getoutline.org/sdk/x v0.2.0
 	golang.org/x/crypto v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/things-go/go-socks5 v0.0.5 h1:qvKaGcBkfDrUL33SchHN93srAmYGzb4CxSM2DPYufe8=
 github.com/things-go/go-socks5 v0.0.5/go.mod h1:mtzInf8v5xmsBpHZVbIw2YQYhc4K0jRwzfsH64Uh0IQ=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.getoutline.org/sdk v0.0.23 h1:UKoKCrRH3Ed6Jpg8ODYwOo6O1B1lvfIHPreMrTkSTcc=


### PR DESCRIPTION
device_test.go is the only user of go.uber.org/atomic; the rest of the project uses stdlib sync/atomic. This switches the only use of go.uber.org/atomic to stdlib, allowing the dependency to be dropped.