### PR TITLE
device: rebase transport padding after TUN read

### DIFF
--- a/device/s4_startup_race_test.go
+++ b/device/s4_startup_race_test.go
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2026 WireGuard LLC. All Rights Reserved.
+ */
+
+package device
+
+import (
+	"fmt"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/amnezia-vpn/amneziawg-go/v3/conn"
+	"github.com/amnezia-vpn/amneziawg-go/v3/tun"
+	"github.com/amnezia-vpn/amneziawg-go/v3/tun/tuntest"
+)
+
+type gatedTUN struct {
+	tun.Device
+	readStarted chan struct{}
+	release     <-chan struct{}
+	once        sync.Once
+}
+
+func (tun *gatedTUN) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	tun.once.Do(func() { close(tun.readStarted) })
+	<-tun.release
+	return tun.Device.Read(bufs, sizes, offset)
+}
+
+func configureDevice(t *testing.T, device *Device, config string) {
+	t.Helper()
+	if err := device.IpcSet(config); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTransportPaddingChangeDuringTUNRead(t *testing.T) {
+	const transportPadding = "25"
+
+	configs, endpointConfigs := genConfigs(t, "s4", transportPadding)
+	rawTUN0 := tuntest.NewChannelTUN()
+	rawTUN1 := tuntest.NewChannelTUN()
+	releaseRead := make(chan struct{})
+	gated := &gatedTUN{
+		Device:      rawTUN0.TUN(),
+		readStarted: make(chan struct{}),
+		release:     releaseRead,
+	}
+
+	pair := testPair{
+		{
+			tun: rawTUN0,
+			ip:  netip.AddrFrom4([4]byte{1, 0, 0, 1}),
+			dev: NewDevice(gated, conn.NewDefaultBind(), NewLogger(LogLevelError, "dev0: ")),
+		},
+		{
+			tun: rawTUN1,
+			ip:  netip.AddrFrom4([4]byte{1, 0, 0, 2}),
+			dev: NewDevice(rawTUN1.TUN(), conn.NewDefaultBind(), NewLogger(LogLevelError, "dev1: ")),
+		},
+	}
+	for i := range pair {
+		t.Cleanup(pair[i].dev.Close)
+	}
+
+	select {
+	case <-gated.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first TUN read")
+	}
+
+	configureDevice(t, pair[0].dev, configs[0])
+	configureDevice(t, pair[1].dev, configs[1])
+
+	// Consume the second device's initial pre-configuration read. Its next
+	// read then snapshots the configured S4 before the test traffic arrives.
+	select {
+	case rawTUN1.Outbound <- []byte{0}:
+	case <-time.After(time.Second):
+		t.Fatal("timed out flushing the second device TUN read")
+	}
+
+	for i := range pair {
+		endpointConfigs[i^1] = fmt.Sprintf(endpointConfigs[i^1], pair[i].dev.net.port)
+	}
+	for i := range pair {
+		configureDevice(t, pair[i].dev, endpointConfigs[i])
+	}
+
+	close(releaseRead)
+	pair.Send(t, Ping, nil)
+	pair.Send(t, Pong, nil)
+}
+
+func TestPaddingBounds(t *testing.T) {
+	cases := []struct {
+		name    string
+		padding int
+		valid   bool
+	}{
+		{name: "zero", padding: 0, valid: true},
+		{name: "AWG profile", padding: 25, valid: true},
+		{name: "maximum valid", padding: MaxMessageSize - MessageTransportHeaderSize - 1, valid: true},
+		{name: "exhausts buffer", padding: MaxMessageSize - MessageTransportHeaderSize, valid: false},
+		{name: "uint16 maximum", padding: 1<<16 - 1, valid: false},
+	}
+	for _, key := range []string{"s1", "s2", "s3", "s4"} {
+		for _, tt := range cases {
+			t.Run(key+"/"+tt.name, func(t *testing.T) {
+				rawTUN := tuntest.NewChannelTUN()
+				device := NewDevice(rawTUN.TUN(), conn.NewDefaultBind(), NewLogger(LogLevelError, "device: "))
+				t.Cleanup(device.Close)
+
+				config := fmt.Sprintf("%s=%d\n", key, tt.padding)
+				beforeHeader := device.headers.transport.Load()
+				if !tt.valid {
+					config = fmt.Sprintf("h4=123456\n%s=%d\n", key, tt.padding)
+				}
+				err := device.IpcSet(config)
+				if tt.valid && err != nil {
+					t.Fatalf("%s=%d rejected: %v", key, tt.padding, err)
+				}
+				if !tt.valid && err == nil {
+					t.Fatalf("%s=%d accepted", key, tt.padding)
+				}
+				if !tt.valid && device.headers.transport.Load() != beforeHeader {
+					t.Fatalf("%s=%d partially updated the transport header", key, tt.padding)
+				}
+			})
+		}
+	}
+}

--- a/device/send.go
+++ b/device/send.go
@@ -310,17 +310,36 @@ func (device *Device) RoutineReadFromTUN() {
 	}()
 
 	for {
-		padding := device.paddings.transport.Load()
-		offset := MessageTransportHeaderSize + int(padding)
+		readPadding := device.paddings.transport.Load()
+		readOffset := MessageTransportHeaderSize + int(readPadding)
 
 		// read packets
-		count, readErr = device.tun.device.Read(bufs, sizes, offset)
+		count, readErr = device.tun.device.Read(bufs, sizes, readOffset)
 		for i := 0; i < count; i++ {
 			if sizes[i] < 1 {
 				continue
 			}
 
 			elem := elems[i]
+			padding := readPadding
+			offset := readOffset
+
+			// The TUN read may have blocked while a UAPI configuration update
+			// changed S4. Rebase the packet so its transport header and content
+			// remain aligned with the current transport padding.
+			if currentPadding := device.paddings.transport.Load(); currentPadding != padding {
+				currentOffset := MessageTransportHeaderSize + int(currentPadding)
+				if sizes[i] > len(bufs[i])-currentOffset {
+					continue
+				}
+				copy(
+					bufs[i][currentOffset:currentOffset+sizes[i]],
+					bufs[i][offset:offset+sizes[i]],
+				)
+				padding = currentPadding
+				offset = currentOffset
+			}
+
 			elem.packet = bufs[i][offset : offset+sizes[i]]
 			elem.padding = padding
 

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -807,6 +807,13 @@ func (d *ipcSetDevice) mergeWithDevice(device *Device) error {
 		}
 	}
 
+	paddings := []uint32{d.paddings.init, d.paddings.response, d.paddings.cookie, d.paddings.transport}
+	for i, padding := range paddings {
+		if padding >= uint32(MaxMessageSize-MessageTransportHeaderSize) {
+			return fmt.Errorf("S%d padding must leave room for at least one byte in the TUN buffer", i+1)
+		}
+	}
+
 	device.log.Verbosef("UAPI: Updating h1 padding")
 	device.headers.init.Store(d.headers.init)
 
@@ -820,7 +827,6 @@ func (d *ipcSetDevice) mergeWithDevice(device *Device) error {
 	device.headers.transport.Store(d.headers.transport)
 
 	if !d.headerProtectionKey.IsZero() {
-		paddings := []uint32{d.paddings.init, d.paddings.response, d.paddings.cookie, d.paddings.transport}
 		for i, padding := range paddings {
 			if padding < HeaderCipherNonceSize {
 				return fmt.Errorf("S%d must be more then %d to use headerProtection", i, HeaderCipherNonceSize)


### PR DESCRIPTION
Fixes #168.

## Problem

`RoutineReadFromTUN` captured the transport padding (S4) before a blocking
TUN read. If a UAPI update changed S4 while that read was blocked, the
outbound element retained the old offset while the receiving device classified
the datagram using the new offset. The first transport packet could then be
discarded as an unknown type after a successful handshake.

## Change

- Re-read S4 after `Read` returns. If it changed, move the TUN payload to the
  current offset before IP classification and rebuild the outbound packet
  slice, preserving the in-place AEAD `Seal` layout.
- Drop only a packet that no longer fits after the new offset is applied.
- Reject S1-S4 values that leave no byte for TUN payload, before mutating
  device state.
- Add a gated regression test that deterministically changes S4 while the
  first TUN read is blocked, plus padding boundary and rejection-atomicity
  coverage.

## Validation

All commands ran in `golang:1.25.12` on Linux with `CAP_NET_ADMIN` and
`/dev/net/tun`:

- The new gated test fails 10/10 on `cf9d2dd` without this change.
- Gated regression and padding-bound tests pass 10/10 with `-race`.
- `go test ./device -run '^TestAWGDevicePing$' -count=10 -race=false` passes.
- `go test ./device -run '^TestAWGDevicePing$' -count=10 -race` passes.
- `go build ./...` passes.

`go vet ./...` still reports a pre-existing copylocks warning in
`device/pools_test.go:67`, outside this change.
