### PR TITLE
fix: send the first packet with the configured transport padding

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -249,6 +249,19 @@ func TestAWGDevicePing(t *testing.T) {
 	})
 }
 
+// The TUN reader picks up the transport padding once, before it blocks on the
+// first read, and that happens in NewDevice - before IpcSet has had a chance to
+// set S4. The first packet used to go out without the padding, and the peer
+// dropped it because the message type was not where S4 said it would be.
+func TestAWGDeviceFirstPacketWithTransportPadding(t *testing.T) {
+	goroutineLeakCheck(t)
+
+	pair := genTestPair(t, true, "s4", "25")
+	t.Run("first packet", func(t *testing.T) {
+		pair.Send(t, Ping, nil)
+	})
+}
+
 // Needs to be stopped with Ctrl-C
 func TestAWGHandshakeDevicePing(t *testing.T) {
 	t.Skip("This test is intended to be run manually, not as part of the test suite.")

--- a/device/send.go
+++ b/device/send.go
@@ -315,6 +315,22 @@ func (device *Device) RoutineReadFromTUN() {
 
 		// read packets
 		count, readErr = device.tun.device.Read(bufs, sizes, offset)
+
+		// The padding was read before the blocking read above, so a UAPI update
+		// that lands while we are waiting leaves the packets at an offset that
+		// no longer matches it. Move them, otherwise they go out with the old
+		// padding and the peer cannot locate the message type in them.
+		if updated := device.paddings.transport.Load(); updated != padding {
+			newOffset := MessageTransportHeaderSize + int(updated)
+			for i := 0; i < count; i++ {
+				if sizes[i] < 1 {
+					continue
+				}
+				copy(bufs[i][newOffset:newOffset+sizes[i]], bufs[i][offset:offset+sizes[i]])
+			}
+			padding, offset = updated, newOffset
+		}
+
 		for i := 0; i < count; i++ {
 			if sizes[i] < 1 {
 				continue


### PR DESCRIPTION
## The problem

With `S4` set, the tunnel loses its first data packet.

`device.TestAWGDevicePing` shows it on current `master`, no changes needed:

```
$ go test ./device/ -run TestAWGDevicePing -race=false -count=1
--- FAIL: TestAWGDevicePing (12.00s)
    --- FAIL: TestAWGDevicePing/ping_1.0.0.1 (6.00s)
        device_test.go:245: ping did not transit
    --- FAIL: TestAWGDevicePing/ping_1.0.0.2 (6.00s)
        device_test.go:248: pong did not transit
```

The same test passes on `v0.2.19`. Running one parameter at a time shows `s4` is the only one that breaks it - `jc`, `jmin`, `jmax`, `s1`, `s2`, `s3` and `h1`-`h4` are all fine. Sending three pings in a row shows only the first is lost:

```
--- FAIL: TestIsoS4TwoPings/first
--- PASS: TestIsoS4TwoPings/second
--- PASS: TestIsoS4TwoPings/third
```

## Why

`RoutineReadFromTUN` reads the padding once and then blocks in `Read` with an offset computed from it:

```go
for {
    padding := device.paddings.transport.Load()
    offset := MessageTransportHeaderSize + int(padding)

    count, readErr = device.tun.device.Read(bufs, sizes, offset)
```

The routine is started by `NewDevice`, so it enters that first `Read` before `IpcSet` has applied `S4`. The packet lands at offset 16, while the peer - configured by then - looks for the message type at offset `16+S4`.

Logging the receiving side confirms it. `S4` is 25, and the type is at offset 0 instead of 25:

```
determine: size=64 transportPadding=25 headerRange=4 raw4=04 00 00 00
Received message with unknown type
```

Only the first packet is affected, because the next pass of the loop reads the padding again.

This is a change from `0.2.x`: there the padding was applied in `RoutineSequentialSender`, at send time, so it was always current. The 3.0 refactor moved it to read time and put it before the blocking call.

The cost in practice is one TCP retransmit on the first connection after the device comes up, which is easy to miss but is still a lost packet on every start.

## The change

Re-read the padding after `Read` returns, and move the packets if it changed. This covers a live `S4` change over UAPI as well, not only start-up. The copy only runs when the value actually changed, so the normal path is one atomic load.

## Verification

- the new test fails without the change and passes with it
- `device.TestAWGDevicePing` and `device.TestTwoDevicePing` pass with the change
- `go test ./...` is green, and `go test -race ./device/` is green

Found while adding AmneziaWG 3.0 support to a userspace client, where the first
connection through a fresh tunnel was reliably a second slower than the rest.
