### PR TITLE
fix: wrong trailerLen for HandshakeCookie message

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -263,7 +263,7 @@ func (device *Device) SendHandshakeCookie(initiatingElem *QueueHandshakeElement)
 	padding := int(device.paddings.cookie.Load())
 	trailerLen := max(device.randomTrailer(padding+MessageCookieReplySize), 0)
 
-	buf := make([]byte, padding+MessageCookieReplySize, trailerLen)
+	buf := make([]byte, padding+MessageCookieReplySize+trailerLen)
 
 	crypt := buf[:padding]
 	rand.Read(crypt)


### PR DESCRIPTION
* AWG3.1-related changes indroduced a new bug with HandshakeCookie buffer size. Instead of adding trailerLen to the final size, it is getting provided as a capacity param leading to the wrong behavior and runtime panic while RandomTrailers is used
* Must be the typo :_)