### PR TITLE
feat: implement sticky sockets on FreeBSD

### DIFF
--- a/conn/controlfns_freebsd.go
+++ b/conn/controlfns_freebsd.go
@@ -1,0 +1,38 @@
+//go:build freebsd
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2025 WireGuard LLC. All Rights Reserved.
+ */
+
+package conn
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	controlFns = append(controlFns,
+		// Attempt to enable reporting of the destination address of incoming
+		// datagrams, which is what makes sticky sockets possible: replies can
+		// then be pinned to the address the peer actually dialed, instead of
+		// whatever source the routing table would pick. Essential on
+		// multi-homed systems, where those two differ.
+		func(network, address string, c syscall.RawConn) error {
+			var err error
+			switch network {
+			case "udp4":
+				c.Control(func(fd uintptr) {
+					err = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_RECVDSTADDR, 1)
+				})
+			case "udp6":
+				c.Control(func(fd uintptr) {
+					err = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_RECVPKTINFO, 1)
+				})
+			}
+			return err
+		},
+	)
+}

--- a/conn/sticky_default.go
+++ b/conn/sticky_default.go
@@ -1,4 +1,4 @@
-//go:build !linux || android
+//go:build (!linux && !freebsd) || android
 
 /* SPDX-License-Identifier: MIT
  *
@@ -21,9 +21,9 @@ func (e *StdNetEndpoint) SrcToString() string {
 	return ""
 }
 
-// TODO: macOS, FreeBSD and other BSDs likely do support the sticky sockets
+// TODO: macOS and other BSDs likely do support the sticky sockets
 // {get,set}srcControl feature set, but use alternatively named flags and need
-// ports and require testing.
+// ports and require testing. FreeBSD is ported, see sticky_freebsd.go.
 
 // getSrcFromControl parses the control for PKTINFO and if found updates ep with
 // the source information found.

--- a/conn/sticky_freebsd.go
+++ b/conn/sticky_freebsd.go
@@ -1,0 +1,121 @@
+//go:build freebsd
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2025 WireGuard LLC. All Rights Reserved.
+ */
+
+package conn
+
+import (
+	"net/netip"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// FreeBSD's sticky sockets differ from Linux's in the IPv4 shape only: the
+// kernel reports the destination of a received datagram as a bare in_addr
+// (IP_RECVDSTADDR) rather than an in_pktinfo, and accepts the same structure
+// back to pin the source of an outgoing one (IP_SENDSRCADDR). The two options
+// share one value, so a received control message can be resent verbatim,
+// which is what ep.src stores. IPv6 uses RFC 3542 in6_pktinfo, same as Linux.
+//
+// Semantics verified against a live kernel before this port was written; see
+// spike/sticky-probe.py in pfSense-pkg-AmneziaWG.
+
+const sizeofInAddr = 4
+
+func (e *StdNetEndpoint) SrcIP() netip.Addr {
+	switch len(e.src) {
+	case unix.CmsgSpace(sizeofInAddr):
+		return netip.AddrFrom4([4]byte(e.src[unix.CmsgLen(0) : unix.CmsgLen(0)+4]))
+	case unix.CmsgSpace(unix.SizeofInet6Pktinfo):
+		info := (*unix.Inet6Pktinfo)(unsafe.Pointer(&e.src[unix.CmsgLen(0)]))
+		// TODO: set zone. in order to do so we need to check if the address is
+		// link local, and if it is perform a syscall to turn the ifindex into a
+		// zone string because netip uses string zones.
+		return netip.AddrFrom16(info.Addr)
+	}
+	return netip.Addr{}
+}
+
+func (e *StdNetEndpoint) SrcIfidx() int32 {
+	// IP_RECVDSTADDR carries no interface index. IPV6_PKTINFO does.
+	if len(e.src) == unix.CmsgSpace(unix.SizeofInet6Pktinfo) {
+		info := (*unix.Inet6Pktinfo)(unsafe.Pointer(&e.src[unix.CmsgLen(0)]))
+		return int32(info.Ifindex)
+	}
+	return 0
+}
+
+func (e *StdNetEndpoint) SrcToString() string {
+	return e.SrcIP().String()
+}
+
+// getSrcFromControl parses the control for IP_RECVDSTADDR/IPV6_PKTINFO and if
+// found updates ep with the source information found.
+func getSrcFromControl(control []byte, ep *StdNetEndpoint) {
+	ep.ClearSrc()
+
+	var (
+		hdr  unix.Cmsghdr
+		data []byte
+		rem  []byte = control
+		err  error
+	)
+
+	for len(rem) > unix.SizeofCmsghdr {
+		hdr, data, rem, err = unix.ParseOneSocketControlMessage(rem)
+		if err != nil {
+			return
+		}
+
+		if hdr.Level == unix.IPPROTO_IP &&
+			hdr.Type == unix.IP_RECVDSTADDR {
+
+			if ep.src == nil || cap(ep.src) < unix.CmsgSpace(sizeofInAddr) {
+				ep.src = make([]byte, 0, unix.CmsgSpace(sizeofInAddr))
+			}
+			ep.src = ep.src[:unix.CmsgSpace(sizeofInAddr)]
+
+			hdrBuf := unsafe.Slice((*byte)(unsafe.Pointer(&hdr)), unix.SizeofCmsghdr)
+			copy(ep.src, hdrBuf)
+			copy(ep.src[unix.CmsgLen(0):], data)
+			return
+		}
+
+		if hdr.Level == unix.IPPROTO_IPV6 &&
+			hdr.Type == unix.IPV6_PKTINFO {
+
+			if ep.src == nil || cap(ep.src) < unix.CmsgSpace(unix.SizeofInet6Pktinfo) {
+				ep.src = make([]byte, 0, unix.CmsgSpace(unix.SizeofInet6Pktinfo))
+			}
+
+			ep.src = ep.src[:unix.CmsgSpace(unix.SizeofInet6Pktinfo)]
+
+			hdrBuf := unsafe.Slice((*byte)(unsafe.Pointer(&hdr)), unix.SizeofCmsghdr)
+			copy(ep.src, hdrBuf)
+			copy(ep.src[unix.CmsgLen(0):], data)
+			return
+		}
+	}
+}
+
+// setSrcControl appends the stored control message to control. On FreeBSD the
+// stored IP_RECVDSTADDR message doubles as IP_SENDSRCADDR (they share a value),
+// and IPV6_PKTINFO is symmetric by design. control's len will be set to 0 in
+// the event that ep is a default value.
+func setSrcControl(control *[]byte, ep *StdNetEndpoint) {
+	if cap(*control) < len(ep.src) {
+		return
+	}
+	*control = (*control)[:0]
+	*control = append(*control, ep.src...)
+}
+
+// stickyControlSize returns the recommended buffer size for pooling sticky
+// offloading control data.
+var stickyControlSize = unix.CmsgSpace(unix.SizeofInet6Pktinfo)
+
+const StdNetSupportsStickySockets = true

--- a/conn/sticky_freebsd_test.go
+++ b/conn/sticky_freebsd_test.go
@@ -1,0 +1,294 @@
+//go:build freebsd
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2025 WireGuard LLC. All Rights Reserved.
+ */
+
+package conn
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Mirrors sticky_linux_test.go, adjusted for the FreeBSD shapes: IPv4 carries a
+// bare in_addr under IP_RECVDSTADDR (no interface index), IPv6 keeps the RFC
+// 3542 in6_pktinfo.
+//
+// Build for the firewall and run it there -- these assert against the kernel's
+// own constants and struct layouts, so a host run would prove nothing:
+//
+//	GOOS=freebsd GOARCH=amd64 go test -c -o sticky.test ./conn/
+//	scp sticky.test admin@FIREWALL:/root/ && ssh admin@FIREWALL './sticky.test -test.v'
+
+func setSrc(ep *StdNetEndpoint, addr netip.Addr, ifidx int32) {
+	var buf []byte
+	if addr.Is4() {
+		buf = make([]byte, unix.CmsgSpace(sizeofInAddr))
+		hdr := unix.Cmsghdr{
+			Level: unix.IPPROTO_IP,
+			Type:  unix.IP_RECVDSTADDR,
+		}
+		hdr.SetLen(unix.CmsgLen(sizeofInAddr))
+		copy(buf, unsafe.Slice((*byte)(unsafe.Pointer(&hdr)), int(unsafe.Sizeof(hdr))))
+
+		as4 := addr.As4()
+		copy(buf[unix.CmsgLen(0):], as4[:])
+	} else {
+		buf = make([]byte, unix.CmsgSpace(unix.SizeofInet6Pktinfo))
+		hdr := unix.Cmsghdr{
+			Level: unix.IPPROTO_IPV6,
+			Type:  unix.IPV6_PKTINFO,
+		}
+		hdr.SetLen(unix.CmsgLen(unix.SizeofInet6Pktinfo))
+		copy(buf, unsafe.Slice((*byte)(unsafe.Pointer(&hdr)), int(unsafe.Sizeof(hdr))))
+
+		info := unix.Inet6Pktinfo{
+			Ifindex: uint32(ifidx),
+			Addr:    addr.As16(),
+		}
+		copy(buf[unix.CmsgLen(0):], unsafe.Slice((*byte)(unsafe.Pointer(&info)), unix.SizeofInet6Pktinfo))
+	}
+
+	ep.src = buf
+}
+
+// The reason the whole port is only a few dozen lines: on FreeBSD the option
+// that reports a datagram's destination and the one that pins an outgoing
+// source are the same number, so a received control message is resent as-is.
+func Test_sendAndRecvOptionsMatch(t *testing.T) {
+	if unix.IP_SENDSRCADDR != unix.IP_RECVDSTADDR {
+		t.Fatalf("IP_SENDSRCADDR (%d) != IP_RECVDSTADDR (%d): the stored cmsg can no longer be resent verbatim",
+			unix.IP_SENDSRCADDR, unix.IP_RECVDSTADDR)
+	}
+}
+
+func Test_setSrcControl(t *testing.T) {
+	t.Run("IPv4", func(t *testing.T) {
+		ep := &StdNetEndpoint{
+			AddrPort: netip.MustParseAddrPort("127.0.0.1:1234"),
+		}
+		setSrc(ep, netip.MustParseAddr("127.0.0.1"), 0)
+
+		control := make([]byte, stickyControlSize)
+
+		setSrcControl(&control, ep)
+
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		if hdr.Level != unix.IPPROTO_IP {
+			t.Errorf("unexpected level: %d", hdr.Level)
+		}
+		if hdr.Type != unix.IP_SENDSRCADDR {
+			t.Errorf("unexpected type: %d", hdr.Type)
+		}
+		if uint(hdr.Len) != uint(unix.CmsgLen(sizeofInAddr)) {
+			t.Errorf("unexpected length: %d", hdr.Len)
+		}
+		addr := control[unix.CmsgLen(0) : unix.CmsgLen(0)+4]
+		if addr[0] != 127 || addr[1] != 0 || addr[2] != 0 || addr[3] != 1 {
+			t.Errorf("unexpected address: %v", addr)
+		}
+	})
+
+	t.Run("IPv6", func(t *testing.T) {
+		ep := &StdNetEndpoint{
+			AddrPort: netip.MustParseAddrPort("[::1]:1234"),
+		}
+		setSrc(ep, netip.MustParseAddr("::1"), 5)
+
+		control := make([]byte, stickyControlSize)
+
+		setSrcControl(&control, ep)
+
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		if hdr.Level != unix.IPPROTO_IPV6 {
+			t.Errorf("unexpected level: %d", hdr.Level)
+		}
+		if hdr.Type != unix.IPV6_PKTINFO {
+			t.Errorf("unexpected type: %d", hdr.Type)
+		}
+		info := (*unix.Inet6Pktinfo)(unsafe.Pointer(&control[unix.CmsgLen(0)]))
+		if info.Ifindex != 5 {
+			t.Errorf("unexpected ifindex: %d", info.Ifindex)
+		}
+	})
+
+	t.Run("ClearOnNoSrc", func(t *testing.T) {
+		control := make([]byte, stickyControlSize)
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		hdr.Level = 1
+		hdr.Type = 2
+		hdr.Len = 3
+
+		setSrcControl(&control, &StdNetEndpoint{})
+
+		if len(control) != 0 {
+			t.Errorf("unexpected control: %v", control)
+		}
+	})
+}
+
+func Test_getSrcFromControl(t *testing.T) {
+	t.Run("IPv4", func(t *testing.T) {
+		control := make([]byte, unix.CmsgSpace(sizeofInAddr))
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		hdr.Level = unix.IPPROTO_IP
+		hdr.Type = unix.IP_RECVDSTADDR
+		hdr.SetLen(unix.CmsgLen(sizeofInAddr))
+		copy(control[unix.CmsgLen(0):], []byte{127, 0, 0, 1})
+
+		ep := &StdNetEndpoint{}
+		getSrcFromControl(control, ep)
+
+		if ep.SrcIP() != netip.MustParseAddr("127.0.0.1") {
+			t.Errorf("unexpected address: %v", ep.SrcIP())
+		}
+		// IP_RECVDSTADDR carries no ifindex; zero is correct, not a failure.
+		if ep.SrcIfidx() != 0 {
+			t.Errorf("unexpected ifindex: %d", ep.SrcIfidx())
+		}
+	})
+
+	t.Run("IPv6", func(t *testing.T) {
+		control := make([]byte, unix.CmsgSpace(unix.SizeofInet6Pktinfo))
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		hdr.Level = unix.IPPROTO_IPV6
+		hdr.Type = unix.IPV6_PKTINFO
+		hdr.SetLen(unix.CmsgLen(unix.SizeofInet6Pktinfo))
+		info := (*unix.Inet6Pktinfo)(unsafe.Pointer(&control[unix.CmsgLen(0)]))
+		info.Addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+		info.Ifindex = 5
+
+		ep := &StdNetEndpoint{}
+		getSrcFromControl(control, ep)
+
+		if ep.SrcIP() != netip.MustParseAddr("::1") {
+			t.Errorf("unexpected address: %v", ep.SrcIP())
+		}
+		if ep.SrcIfidx() != 5 {
+			t.Errorf("unexpected ifindex: %d", ep.SrcIfidx())
+		}
+	})
+
+	t.Run("ClearOnEmpty", func(t *testing.T) {
+		var control []byte
+		ep := &StdNetEndpoint{}
+		setSrc(ep, netip.MustParseAddr("::1"), 5)
+
+		getSrcFromControl(control, ep)
+		if ep.SrcIP().IsValid() {
+			t.Errorf("unexpected address: %v", ep.SrcIP())
+		}
+		if ep.SrcIfidx() != 0 {
+			t.Errorf("unexpected ifindex: %d", ep.SrcIfidx())
+		}
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		zeroControl := make([]byte, unix.CmsgSpace(0))
+		zeroHdr := (*unix.Cmsghdr)(unsafe.Pointer(&zeroControl[0]))
+		zeroHdr.SetLen(unix.CmsgLen(0))
+
+		control := make([]byte, unix.CmsgSpace(sizeofInAddr))
+		hdr := (*unix.Cmsghdr)(unsafe.Pointer(&control[0]))
+		hdr.Level = unix.IPPROTO_IP
+		hdr.Type = unix.IP_RECVDSTADDR
+		hdr.SetLen(unix.CmsgLen(sizeofInAddr))
+		copy(control[unix.CmsgLen(0):], []byte{127, 0, 0, 1})
+
+		combined := make([]byte, 0)
+		combined = append(combined, zeroControl...)
+		combined = append(combined, control...)
+
+		ep := &StdNetEndpoint{}
+		getSrcFromControl(combined, ep)
+
+		if ep.SrcIP() != netip.MustParseAddr("127.0.0.1") {
+			t.Errorf("unexpected address: %v", ep.SrcIP())
+		}
+	})
+}
+
+// The round trip that matters, against the real kernel: a socket bound to the
+// wildcard learns which local address a datagram was sent to, and the reply can
+// be pinned back to it. This is the whole mechanism the multi-WAN fix rests on.
+func Test_stickyRoundTrip(t *testing.T) {
+	// Wildcard, as StdNetBind.Open does. IP_SENDSRCADDR is rejected with
+	// EINVAL on a socket already bound to one address -- there is nothing to
+	// override there -- so binding 127.0.0.1 here would fail for a reason that
+	// has nothing to do with the port.
+	sock, err := listenConfig().ListenPacket(context.Background(), "udp4", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sock.Close()
+
+	conn := sock.(*net.UDPConn)
+
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// The wildcard socket's LocalAddr has no address; dial it on loopback.
+	srvAddr := &net.UDPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: conn.LocalAddr().(*net.UDPAddr).Port,
+	}
+
+	if _, err := client.WriteToUDP([]byte("probe"), srvAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 128)
+	oob := make([]byte, stickyControlSize)
+
+	n, oobn, _, from, err := conn.ReadMsgUDP(buf, oob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "probe" {
+		t.Fatalf("unexpected payload: %q", buf[:n])
+	}
+
+	ep := &StdNetEndpoint{AddrPort: from.AddrPort()}
+	getSrcFromControl(oob[:oobn], ep)
+
+	// listenConfig() must have enabled IP_RECVDSTADDR for this to be populated;
+	// an empty src here means controlfns_freebsd.go never ran.
+	if !ep.SrcIP().IsValid() {
+		t.Fatal("no source address recovered: IP_RECVDSTADDR was not enabled by listenConfig()")
+	}
+	if ep.SrcIP() != netip.MustParseAddr("127.0.0.1") {
+		t.Errorf("unexpected source: %v", ep.SrcIP())
+	}
+
+	var replyOOB []byte = make([]byte, 0, stickyControlSize)
+	setSrcControl(&replyOOB, ep)
+
+	if len(replyOOB) == 0 {
+		t.Fatal("setSrcControl produced nothing to send")
+	}
+
+	if _, _, err := conn.WriteMsgUDP([]byte("reply"), replyOOB, from); err != nil {
+		t.Fatalf("sending with a pinned source failed: %v", err)
+	}
+
+	rn, replyFrom, err := client.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:rn]) != "reply" {
+		t.Fatalf("unexpected reply: %q", buf[:rn])
+	}
+	if !replyFrom.IP.Equal(net.IPv4(127, 0, 0, 1)) {
+		t.Errorf("reply came from %v", replyFrom.IP)
+	}
+}


### PR DESCRIPTION
## What this does

Fills in `getSrcFromControl()` / `setSrcControl()` for FreeBSD, so a socket answers from the address the packet arrived on instead of whatever routing picks. This is the open `TODO` in `conn/sticky_default.go`.

The generic transport already does the work on every platform — the non-Linux path in `bind_std.go` uses `ReadMsgUDP`/`WriteMsgUDP` with OOB — only the implementations were empty outside Linux.

## Why FreeBSD is easy

It has the whole API:

| | IPv4 | IPv6 |
|---|---|---|
| enable | `IP_RECVDSTADDR` | `IPV6_RECVPKTINFO` |
| receive | `in_addr` | `in6_pktinfo` |
| send | `IP_SENDSRCADDR` | `IPV6_PKTINFO` |

And `IP_SENDSRCADDR == IP_RECVDSTADDR` (both 7), so the control message that came in can be handed straight back to `sendmsg` — the same trick the Linux code uses by keeping the raw cmsg in `ep.src`. IPv6 is symmetric on its own.

## Why it matters

On a multi-homed host without sticky sockets, a handshake arriving on a secondary WAN gets answered out of the default gateway's interface with the wrong source address; the client discards it and the handshake never completes.

Concretely, on a pfSense firewall with two WANs, before and after:

| | before | after |
|---|---|---|
| pf states | two — one inbound, one outbound on the other interface | one, matching the WAN rule |
| packets out the secondary WAN | none | reply leaves with the dialed address |
| handshake | never completes | completes on the first try |

That is the behaviour `if_wg` already has in kernel, so this closes the gap for the userspace implementation.

## Verification

- `go test ./conn/` on FreeBSD 16 (pfSense 2.9.0), including a round trip that exercises `listenConfig()`, the cmsg parse, and a `sendmsg` with the source pinned against the real kernel.
- `go build ./conn/` and `go vet ./conn/` for `freebsd`, `linux`, `windows`, `darwin` and `openbsd` — the build tag change (`!linux || android` → `(!linux && !freebsd) || android`) leaves every other platform on the stub.
- A real client completing handshakes and passing traffic over both WANs, including the one without the default route.

## Two notes

Anyone extending `sticky_freebsd_test.go` should know that `IP_SENDSRCADDR` returns `EINVAL` on a socket bound to a specific address — it only works with a wildcard bind, which is what `StdNetBind.Open()` does. The code is unaffected, but a test binding `127.0.0.1` fails for that reason alone.

Unrelated to this change: `GOOS=freebsd go build ./...` on current `master` fails in `golang.getoutline.org/sdk/x/smart` (`undefined: lookupCNAME`), so the repo does not build for FreeBSD today. The `conn` package itself is fine, which is what this patch touches.

The change applies identically to `wireguard-go`, which is where these files come from.
